### PR TITLE
Make Boost_USE_STATIC_LIBS a cache variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ endif()
 # Boost ------------------------------------------------------------------------
 
 set(Boost_USE_MULTITHREAD ON)
-set(Boost_USE_STATIC_LIBS ON)
+set(Boost_USE_STATIC_LIBS ON CACHE BOOL)
 set(Boost_USE_STATIC_RUNTIME OFF)
 
 find_package(Boost 1.68 COMPONENTS system program_options filesystem date_time REQUIRED)


### PR DESCRIPTION
Like this we can overwrite it's value from the commandline via
`-DBoost_USE_STATIC_LIBS=OFF`.

Linux distributions will prefer this.

Regards https://github.com/CoatiSoftware/Sourcetrail/issues/758