### PR TITLE
Always return a value from non void function elide()

### DIFF
--- a/src/lib_utility/utility/utilityString.cpp
+++ b/src/lib_utility/utility/utilityString.cpp
@@ -580,6 +580,8 @@ std::string elide(const std::string& str, ElideMode mode, size_t size)
 	case ELIDE_RIGHT:
 		return str.substr(0, size - 3) + "...";
 	}
+
+	return "";
 }
 
 std::wstring elide(const std::wstring& str, ElideMode mode, size_t size)
@@ -599,6 +601,8 @@ std::wstring elide(const std::wstring& str, ElideMode mode, size_t size)
 	case ELIDE_RIGHT:
 		return str.substr(0, size - 3) + L"...";
 	}
+
+	return "";
 }
 
 std::wstring convertWhiteSpacesToSingleSpaces(const std::wstring& str)


### PR DESCRIPTION
elide() needs to always return std:string.

We cover all cases because our switch contains all current possibilities
for ElideMode.

But the compiler will still warn/error on this, depending on system
configuration.

I would like to add a `return "";` or `return str;` or add a `default:`
case to the switch to silence this compiler complaint.