### PR TITLE
src: Always return a value from non void function getSearchTypeName()

### DIFF
--- a/src/lib/data/search/SearchMatch.cpp
+++ b/src/lib/data/search/SearchMatch.cpp
@@ -33,6 +33,8 @@ std::wstring SearchMatch::getSearchTypeName(SearchType type)
 	case SEARCH_FULLTEXT:
 		return L"fulltext";
 	}
+
+	return L"none";
 }
 
 std::wstring SearchMatch::searchMatchesToString(const std::vector<SearchMatch>& matches)


### PR DESCRIPTION
getSearchTypeName() needs to always return std:wstring.

We cover all cases because our switch contains all current possibilities
for Search_Type.

But the compiler will still warn/error on this, depending on system
configuration.

Regards https://github.com/CoatiSoftware/Sourcetrail/issues/758