### PR TITLE
fix building with clang 9

### DIFF
--- a/src/lib_cxx/data/parser/cxx/ClangInvocationInfo.cpp
+++ b/src/lib_cxx/data/parser/cxx/ClangInvocationInfo.cpp
@@ -61,7 +61,7 @@ ClangInvocationInfo ClangInvocationInfo::getClangInvocationString(
 			new clang::FileManager(clang::FileSystemOptions()));
 
 		const std::unique_ptr<clang::driver::Driver> Driver(
-			newDriver(&Diagnostics, BinaryName, Files->getVirtualFileSystem()));
+			newDriver(&Diagnostics, BinaryName, &Files->getVirtualFileSystem()));
 		// Since the input might only be virtual, don't check whether it exists.
 		Driver->setCheckInputsExist(false);
 		const std::unique_ptr<clang::driver::Compilation> Compilation(

--- a/src/lib_cxx/data/parser/cxx/GeneratePCHAction.cpp
+++ b/src/lib_cxx/data/parser/cxx/GeneratePCHAction.cpp
@@ -36,14 +36,11 @@ std::unique_ptr<clang::ASTConsumer> GeneratePCHAction::CreateASTConsumer(
 	const auto& FrontendOpts = CI.getFrontendOpts();
 	auto Buffer = std::make_shared<clang::PCHBuffer>();
 	std::vector<std::unique_ptr<clang::ASTConsumer>> Consumers;
-	Consumers.push_back(llvm::make_unique<clang::PCHGenerator>(
-		CI.getPreprocessor(),
-		OutputFile,
-		Sysroot,
-		Buffer,
+	Consumers.push_back(std::make_unique<clang::PCHGenerator>(
+		CI.getPreprocessor(), CI.getModuleCache(), OutputFile, Sysroot, Buffer,
 		FrontendOpts.ModuleFileExtensions,
 		true,
-		FrontendOpts.IncludeTimestamps));
+		FrontendOpts.IncludeTimestamps, +CI.getLangOpts().CacheGeneratedPCH));
 	Consumers.push_back(CI.getPCHContainerWriter().CreatePCHContainerGenerator(
 		CI, InFile, OutputFile, std::move(OS), Buffer));
 


### PR DESCRIPTION
There seems to be some API change in the new clang version.
Fix by copying the code from the clang source code.