### PR TITLE
Fix a possible cmake error on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -677,8 +677,8 @@ if (APPLE)
 	string(REPLACE ";" " " MACOS_QT_FRAMEWORKS "${MACOS_QT_FRAMEWORKS}")
 
 	set(MACOS_BOOST_DIR "${Boost_INCLUDE_DIR}")
-	STRING(REGEX REPLACE "/lib/cmake/clang" "" MACOS_CLANG_DIR ${Clang_DIR})
-	STRING(REGEX REPLACE "/lib/cmake/Qt5" "" MACOS_QT_DIR ${Qt5_DIR})
+	STRING(REGEX REPLACE "/lib/cmake/clang" "" MACOS_CLANG_DIR "${Clang_DIR}")
+	STRING(REGEX REPLACE "/lib/cmake/Qt5" "" MACOS_QT_DIR "${Qt5_DIR}")
 
 	configure_file(
 		${PROJECT_SOURCE_DIR}/setup/macOS/bundle_install.sh.in


### PR DESCRIPTION
The last part should be quoted, or there might be error like

```
CMake Error at CMakeLists.txt:680 (STRING):
  STRING sub-command REGEX, mode REPLACE needs at least 6 arguments total to
  command.
```