### PR TITLE
Fix crash on exit

### DIFF
--- a/src/lib/component/ComponentManager.cpp
+++ b/src/lib/component/ComponentManager.cpp
@@ -15,6 +15,16 @@
 #include "ViewFactory.h"
 #include "logging.h"
 
+namespace
+{
+template <class Container>
+void reverseErase(Container & container)
+{
+	while(!container.empty())
+		container.pop_back();
+}
+}	 // namespace
+
 ComponentManager::ComponentManager(const ViewFactory* viewFactory, StorageAccess* storageAccess)
 	: m_componentFactory(viewFactory, storageAccess)
 {
@@ -23,8 +33,8 @@ ComponentManager::ComponentManager(const ViewFactory* viewFactory, StorageAccess
 void ComponentManager::clear()
 {
 	m_dialogViews.clear();
-	m_components.clear();
-	m_singleViews.clear();
+	reverseErase(m_components);
+	reverseErase(m_singleViews);
 }
 
 void ComponentManager::setupMain(ViewLayout* viewLayout, Id appId)

--- a/src/lib/data/graph/Token.h
+++ b/src/lib/data/graph/Token.h
@@ -3,6 +3,7 @@
 
 #include <typeinfo>
 #include <vector>
+#include <string>
 
 #include "TokenComponent.h"
 #include "types.h"

--- a/src/lib_cxx/utility/codeblocks/CodeblocksCompiler.h
+++ b/src/lib_cxx/utility/codeblocks/CodeblocksCompiler.h
@@ -2,8 +2,8 @@
 #define CODEBLOCKS_COMPILER_H
 
 #include <memory>
-#include <set>
 #include <vector>
+#include <string>
 
 class TiXmlElement;
 


### PR DESCRIPTION
I've caught an exeption on app exit:

> Exception thrown: read access violation.
> screenSearchSender->**** was 0xFFFFFFFFFFFFFFE7

The problem is that `TabsController` depends on `ScreenSearchController` and  `ScreenSearchController` gets destroyed before `TabsController` leaving him hanging on a dead object.

The proposed solution is to destroy components in the order reverse to creation

Steps to reproduce:
1) start sourcetrail
2) open any project for example 'tutorial.srctrlprj'
3) close sourcetrail

<details>
<summary>Full stacktrace</summary>

```
Sourcetrail.exe!ComponentManager::teardownTab(ScreenSearchSender * screenSearchSender) Line 200	C++
Sourcetrail.exe!Tab::~Tab() Line 22	C++
Sourcetrail.exe!Tab::`scalar deleting destructor'(unsigned int)	C++
Sourcetrail.exe!std::_Destroy_in_place<Tab>(Tab & _Obj) Line 323	C++
Sourcetrail.exe!std::_Ref_count_obj2<Tab>::_Destroy() Line 1507	C++
Sourcetrail.exe!std::_Ref_count_base::_Decref() Line 653	C++
Sourcetrail.exe!std::_Ptr_base<Tab>::_Decref() Line 885	C++
Sourcetrail.exe!std::shared_ptr<Tab>::~shared_ptr<Tab>() Line 1134	C++
Sourcetrail.exe!std::pair<unsigned __int64 const ,std::shared_ptr<Tab>>::~pair<unsigned __int64 const ,std::shared_ptr<Tab>>()	C++
Sourcetrail.exe!std::pair<unsigned __int64 const ,std::shared_ptr<Tab>>::`scalar deleting destructor'(unsigned int)	C++
Sourcetrail.exe!std::_Default_allocator_traits<std::allocator<std::_Tree_node<std::pair<unsigned __int64 const ,std::shared_ptr<Tab>>,void *>>>::destroy<std::pair<unsigned __int64 const ,std::shared_ptr<Tab>>>(std::allocator<std::_Tree_node<std::pair<unsigned __int64 const ,std::shared_ptr<Tab>>,void *>> & __formal, std::pair<unsigned __int64 const ,std::shared_ptr<Tab>> * const _Ptr) Line 764	C++
Sourcetrail.exe!std::_Tree_node<std::pair<unsigned __int64 const ,std::shared_ptr<Tab>>,void *>::_Freenode<std::allocator<std::_Tree_node<std::pair<unsigned __int64 const ,std::shared_ptr<Tab>>,void *>>>(std::allocator<std::_Tree_node<std::pair<unsigned __int64 const ,std::shared_ptr<Tab>>,void *>> & _Al, std::_Tree_node<std::pair<unsigned __int64 const ,std::shared_ptr<Tab>>,void *> * _Ptr) Line 381	C++
Sourcetrail.exe!std::_Tree_val<std::_Tree_simple_types<std::pair<unsigned __int64 const ,std::shared_ptr<Tab>>>>::_Erase_tree<std::allocator<std::_Tree_node<std::pair<unsigned __int64 const ,std::shared_ptr<Tab>>,void *>>>(std::allocator<std::_Tree_node<std::pair<unsigned __int64 const ,std::shared_ptr<Tab>>,void *>> & _Al, std::_Tree_node<std::pair<unsigned __int64 const ,std::shared_ptr<Tab>>,void *> * _Rootnode) Line 747	C++
Sourcetrail.exe!std::_Tree_val<std::_Tree_simple_types<std::pair<unsigned __int64 const ,std::shared_ptr<Tab>>>>::_Erase_head<std::allocator<std::_Tree_node<std::pair<unsigned __int64 const ,std::shared_ptr<Tab>>,void *>>>(std::allocator<std::_Tree_node<std::pair<unsigned __int64 const ,std::shared_ptr<Tab>>,void *>> & _Al) Line 755	C++
Sourcetrail.exe!std::_Tree<std::_Tmap_traits<unsigned __int64,std::shared_ptr<Tab>,std::less<unsigned __int64>,std::allocator<std::pair<unsigned __int64 const ,std::shared_ptr<Tab>>>,0>>::~_Tree<std::_Tmap_traits<unsigned __int64,std::shared_ptr<Tab>,std::less<unsigned __int64>,std::allocator<std::pair<unsigned __int64 const ,std::shared_ptr<Tab>>>,0>>() Line 1193	C++
Sourcetrail.exe!std::map<unsigned __int64,std::shared_ptr<Tab>,std::less<unsigned __int64>,std::allocator<std::pair<unsigned __int64 const ,std::shared_ptr<Tab>>>>::~map<unsigned __int64,std::shared_ptr<Tab>,std::less<unsigned __int64>,std::allocator<std::pair<unsigned __int64 const ,std::shared_ptr<Tab>>>>()	C++
Sourcetrail.exe!TabsController::~TabsController() Line 31	C++
Sourcetrail.exe!TabsController::`scalar deleting destructor'(unsigned int)	C++
Sourcetrail.exe!std::_Destroy_in_place<TabsController>(TabsController & _Obj) Line 323	C++
Sourcetrail.exe!std::_Ref_count_obj2<TabsController>::_Destroy() Line 1507	C++
Sourcetrail.exe!std::_Ref_count_base::_Decref() Line 653	C++
Sourcetrail.exe!std::_Ptr_base<Controller>::_Decref() Line 885	C++
Sourcetrail.exe!std::shared_ptr<Controller>::~shared_ptr<Controller>() Line 1134	C++
Sourcetrail.exe!Component::~Component() Line 38	C++
Sourcetrail.exe!Component::`scalar deleting destructor'(unsigned int)	C++
Sourcetrail.exe!std::_Destroy_in_place<Component>(Component & _Obj) Line 323	C++
Sourcetrail.exe!std::_Ref_count_obj2<Component>::_Destroy() Line 1507	C++
Sourcetrail.exe!std::_Ref_count_base::_Decref() Line 653	C++
Sourcetrail.exe!std::_Ptr_base<Component>::_Decref() Line 885	C++
Sourcetrail.exe!std::shared_ptr<Component>::~shared_ptr<Component>() Line 1134	C++
Sourcetrail.exe!std::shared_ptr<Component>::`scalar deleting destructor'(unsigned int)	C++
Sourcetrail.exe!std::_Default_allocator_traits<std::allocator<std::shared_ptr<Component>>>::destroy<std::shared_ptr<Component>>(std::allocator<std::shared_ptr<Component>> & __formal, std::shared_ptr<Component> * const _Ptr) Line 764	C++
Sourcetrail.exe!std::_Destroy_range<std::allocator<std::shared_ptr<Component>>>(std::shared_ptr<Component> * _First, std::shared_ptr<Component> * const _Last, std::allocator<std::shared_ptr<Component>> & _Al) Line 1038	C++
Sourcetrail.exe!std::vector<std::shared_ptr<Component>,std::allocator<std::shared_ptr<Component>>>::_Destroy(std::shared_ptr<Component> * _First, std::shared_ptr<Component> * _Last) Line 1569	C++
Sourcetrail.exe!std::vector<std::shared_ptr<Component>,std::allocator<std::shared_ptr<Component>>>::clear() Line 1339	C++
Sourcetrail.exe!ComponentManager::clear() Line 36	C++
Sourcetrail.exe!QtMainView::~QtMainView() Line 16	C++
Sourcetrail.exe!QtMainView::`scalar deleting destructor'(unsigned int)	C++
Sourcetrail.exe!std::_Destroy_in_place<QtMainView>(QtMainView & _Obj) Line 323	C++
Sourcetrail.exe!std::_Ref_count_obj2<QtMainView>::_Destroy() Line 1507	C++
Sourcetrail.exe!std::_Ref_count_base::_Decref() Line 653	C++
Sourcetrail.exe!std::_Ptr_base<MainView>::_Decref() Line 885	C++
Sourcetrail.exe!std::shared_ptr<MainView>::~shared_ptr<MainView>() Line 1134	C++
Sourcetrail.exe!Application::~Application() Line 139	C++
Sourcetrail.exe!Application::`scalar deleting destructor'(unsigned int)	C++
Sourcetrail.exe!std::_Ref_count<Application>::_Destroy() Line 680	C++
Sourcetrail.exe!std::_Ref_count_base::_Decref() Line 653	C++
Sourcetrail.exe!std::_Ptr_base<Application>::_Decref() Line 885	C++
Sourcetrail.exe!std::shared_ptr<Application>::~shared_ptr<Application>() Line 1134	C++
Sourcetrail.exe!std::shared_ptr<Application>::reset() Line 1179	C++
Sourcetrail.exe!Application::destroyInstance() Line 95	C++
Sourcetrail.exe!main::__l24::<lambda>() Line 206	C++
Sourcetrail.exe!std::_Invoker_functor::_Call<void <lambda>(void) &>(main::__l24::void <lambda>(void) & _Obj) Line 1571	C++
Sourcetrail.exe!std::invoke<void <lambda>(void) &>(main::__l24::void <lambda>(void) & _Obj) Line 1571	C++
Sourcetrail.exe!std::_Invoker_ret<void,1>::_Call<void <lambda>(void) &>(main::__l24::void <lambda>(void) & <_Vals_0>) Line 1590	C++
Sourcetrail.exe!std::_Func_impl_no_alloc<void <lambda>(void),void>::_Do_call() Line 965	C++
Sourcetrail.exe!std::_Func_class<void>::operator()() Line 1008	C++
Sourcetrail.exe!ScopedFunctor::~ScopedFunctor() Line 9	C++
Sourcetrail.exe!main(int argc, char * * argv) Line 227	C++
Sourcetrail.exe!invoke_main() Line 79	C++
Sourcetrail.exe!__scrt_common_main_seh() Line 288	C++
Sourcetrail.exe!__scrt_common_main() Line 331	C++
Sourcetrail.exe!mainCRTStartup() Line 17	C++
kernel32.dll!00007ffdd1517bd4()	Unknown
ntdll.dll!00007ffdd2f4ced1()	Unknown
```

</details>