### PR TITLE
build: add multiprocessor compilation flag to cmake to speedup builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,8 @@ set(CMAKE_C_STANDARD 99)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-warning-option -fcolor-diagnostics -fvisibility-inlines-hidden")
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+	ADD_COMPILE_OPTIONS(/MP)
 endif()
 
 # For debugging the release build on linux


### PR DESCRIPTION
Make MSVC compiler use all available cores during build