### PR TITLE
logic: improve usability of shallow indexing ui

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -169,7 +169,8 @@ int main(int argc, char *argv[])
 			MessageLoadProject(
 				commandLineParser.getProjectFilePath(),
 				false,
-				commandLineParser.getRefreshMode()
+				commandLineParser.getRefreshMode(),
+				commandLineParser.getShallowIndexingRequested()
 			).dispatch();
 		}
 

--- a/src/lib/app/Application.cpp
+++ b/src/lib/app/Application.cpp
@@ -255,7 +255,7 @@ void Application::handleMessage(MessageLoadProject* message)
 		if (message->settingsChanged && m_hasGUI)
 		{
 			m_project->setStateOutdated();
-			refreshProject(REFRESH_ALL_FILES);
+			refreshProject(REFRESH_ALL_FILES, message->shallowIndexingRequested);
 		}
 	}
 	else
@@ -316,7 +316,7 @@ void Application::handleMessage(MessageLoadProject* message)
 
 		if (message->refreshMode != REFRESH_NONE)
 		{
-			refreshProject(message->refreshMode);
+			refreshProject(message->refreshMode, message->shallowIndexingRequested);
 		}
 	}
 }
@@ -325,7 +325,8 @@ void Application::handleMessage(MessageRefresh* message)
 {
 	TRACE("app refresh");
 
-	refreshProject(message->all ? REFRESH_ALL_FILES : REFRESH_UPDATED_FILES);
+	refreshProject(
+		message->all ? REFRESH_ALL_FILES : REFRESH_UPDATED_FILES, false);
 }
 
 void Application::handleMessage(MessageRefreshUI* message)
@@ -409,11 +410,11 @@ void Application::loadWindow(bool showStartWindow)
 	}
 }
 
-void Application::refreshProject(RefreshMode refreshMode)
+void Application::refreshProject(RefreshMode refreshMode, bool shallowIndexingRequested)
 {
 	if (m_project && checkSharedMemory())
 	{
-		m_project->refresh(refreshMode, getDialogView(DialogView::UseCase::INDEXING));
+		m_project->refresh(getDialogView(DialogView::UseCase::INDEXING), refreshMode, shallowIndexingRequested);
 
 		if (!m_hasGUI && !m_project->isIndexing())
 		{

--- a/src/lib/app/Application.h
+++ b/src/lib/app/Application.h
@@ -79,7 +79,7 @@ private:
 
 	void loadWindow(bool showStartWindow);
 
-	void refreshProject(RefreshMode refreshMode);
+	void refreshProject(RefreshMode refreshMode, bool shallowIndexingRequested);
 	void updateRecentProjects(const FilePath& projectSettingsFilePath);
 
 	void logStorageStats() const;

--- a/src/lib/project/Project.cpp
+++ b/src/lib/project/Project.cpp
@@ -421,7 +421,9 @@ void Project::refresh(std::shared_ptr<DialogView> dialogView, RefreshMode refres
 	}
 	else
 	{
-		buildIndex(getRefreshInfo(refreshMode), dialogView);
+		RefreshInfo info = getRefreshInfo(refreshMode);
+		info.shallow = useShallowIndexing;
+		buildIndex(info, dialogView);
 	}
 }
 

--- a/src/lib/project/Project.cpp
+++ b/src/lib/project/Project.cpp
@@ -272,7 +272,7 @@ void Project::load(std::shared_ptr<DialogView> dialogView)
 	}
 }
 
-void Project::refresh(RefreshMode refreshMode, std::shared_ptr<DialogView> dialogView)
+void Project::refresh(std::shared_ptr<DialogView> dialogView, RefreshMode refreshMode, bool shallowIndexingRequested)
 {
 	if (m_refreshStage != RefreshStageType::NONE)
 	{
@@ -399,8 +399,7 @@ void Project::refresh(RefreshMode refreshMode, std::shared_ptr<DialogView> dialo
 		}
 	}
 
-	const bool useShallowIndexing = allowsShallowIndexing &&
-		(!isLoaded() || m_state == PROJECT_STATE_EMPTY);
+	const bool useShallowIndexing = allowsShallowIndexing && shallowIndexingRequested;
 
 	if (m_hasGUI)
 	{

--- a/src/lib/project/Project.h
+++ b/src/lib/project/Project.h
@@ -37,7 +37,7 @@ public:
 
 	void load(std::shared_ptr<DialogView> dialogView);
 
-	void refresh(RefreshMode refreshMode, std::shared_ptr<DialogView> dialogView);
+	void refresh(std::shared_ptr<DialogView> dialogView, RefreshMode refreshMode, bool shallowIndexingRequested);
 
 	RefreshInfo getRefreshInfo(RefreshMode mode) const;
 

--- a/src/lib/project/RefreshInfo.h
+++ b/src/lib/project/RefreshInfo.h
@@ -20,7 +20,7 @@ struct RefreshInfo
 	std::set<FilePath> nonIndexedFilesToClear;
 
 	RefreshMode mode = REFRESH_NONE;
-	bool shallow = true;
+	bool shallow = false;
 };
 
 #endif	  // REFRESH_INFO_H

--- a/src/lib/utility/commandline/CommandLineParser.cpp
+++ b/src/lib/utility/commandline/CommandLineParser.cpp
@@ -18,29 +18,25 @@ namespace commandline
 {
 CommandLineParser::CommandLineParser(const std::string& version): m_version(version)
 {
-	setup();
-}
-
-CommandLineParser::~CommandLineParser() {}
-
-void CommandLineParser::setup()
-{
 	po::options_description options("Options");
-	options.add_options()("help,h", "Print this help message")(
-		"version,v", "Version of Sourcetrail")(
-		"project-file", po::value<std::string>(), "Open Sourcetrail with this project (.srctrlprj)");
+	options.add_options()
+		("help,h", "Print this help message")
+		("version,v", "Version of Sourcetrail")
+		("project-file", po::value<std::string>(), "Open Sourcetrail with this project (.srctrlprj)");
 
 	m_options.add(options);
 	m_positional.add("project-file", 1);
 
-	addCommand(std::make_unique<commandline::CommandlineCommandConfig>(this));
-	addCommand(std::make_unique<commandline::CommandlineCommandIndex>(this));
+	m_commands.push_back(std::make_unique<commandline::CommandlineCommandConfig>(this));
+	m_commands.push_back(std::make_unique<commandline::CommandlineCommandIndex>(this));
 
-	for (auto& command: m_commands)
+	for (auto& command : m_commands)
 	{
 		command->setup();
 	}
 }
+
+CommandLineParser::~CommandLineParser() {}
 
 void CommandLineParser::preparse(int argc, char** argv)
 {
@@ -148,11 +144,6 @@ void CommandLineParser::setProjectFile(const FilePath& filepath)
 	processProjectfile();
 }
 
-void CommandLineParser::addCommand(std::unique_ptr<CommandlineCommand> command)
-{
-	m_commands.push_back(std::move(command));
-}
-
 void CommandLineParser::printHelp() const
 {
 	std::cout << "Usage:\n  Sourcetrail [command] [option...] [positional arguments]\n\n";
@@ -240,6 +231,11 @@ void CommandLineParser::incompleteRefresh()
 	m_refreshMode = REFRESH_UPDATED_AND_INCOMPLETE_FILES;
 }
 
+void CommandLineParser::setShallowIndexingRequested(bool enabled)
+{
+	m_shallowIndexingRequested = enabled;
+}
+
 const FilePath& CommandLineParser::getProjectFilePath() const
 {
 	return m_projectFile;
@@ -248,6 +244,11 @@ const FilePath& CommandLineParser::getProjectFilePath() const
 RefreshMode CommandLineParser::getRefreshMode() const
 {
 	return m_refreshMode;
+}
+
+bool CommandLineParser::getShallowIndexingRequested() const
+{
+	return m_shallowIndexingRequested;
 }
 
 }	 // namespace commandline

--- a/src/lib/utility/commandline/CommandLineParser.h
+++ b/src/lib/utility/commandline/CommandLineParser.h
@@ -22,8 +22,6 @@ public:
 	CommandLineParser(const std::string& version);
 	~CommandLineParser();
 
-	void setup();
-
 	void preparse(int argc, char** argv);
 	void preparse(std::vector<std::string>& args);
 	void parse();
@@ -36,14 +34,15 @@ public:
 
 	void fullRefresh();
 	void incompleteRefresh();
+	void setShallowIndexingRequested(bool enabled = true);
 
 	const FilePath& getProjectFilePath() const;
 	void setProjectFile(const FilePath& filepath);
 
 	RefreshMode getRefreshMode() const;
+	bool getShallowIndexingRequested() const;
 
 private:
-	void addCommand(std::unique_ptr<CommandlineCommand> command);
 	void processProjectfile();
 	void printHelp() const;
 
@@ -56,6 +55,7 @@ private:
 	const std::string m_version;
 	FilePath m_projectFile;
 	RefreshMode m_refreshMode = REFRESH_UPDATED_FILES;
+	bool m_shallowIndexingRequested = false;
 
 	bool m_quit = false;
 	bool m_withoutGUI = false;

--- a/src/lib/utility/commandline/commands/CommandlineCommandIndex.cpp
+++ b/src/lib/utility/commandline/commands/CommandlineCommandIndex.cpp
@@ -19,10 +19,12 @@ CommandlineCommandIndex::~CommandlineCommandIndex() {}
 void CommandlineCommandIndex::setup()
 {
 	po::options_description options("Config Options");
-	options.add_options()("help,h", "Print this help message")(
-		"incomplete,i", "Also reindex incomplete files (files with errors)")(
-		"full,f", "Index full project (omit to only index new/changed files)")(
-		"project-file", po::value<std::string>(), "Project file to index (.srctrlprj)");
+	options.add_options()
+		("help,h", "Print this help message")
+		("incomplete,i", "Also reindex incomplete files (files with errors)")
+		("full,f", "Index full project (omit to only index new/changed files)")
+		("shallow,s", "Build a shallow index is supported by the project")
+		("project-file", po::value<std::string>(), "Project file to index (.srctrlprj)");
 
 	m_options.add(options);
 	m_positional.add("project-file", 1);
@@ -59,6 +61,11 @@ CommandlineCommand::ReturnStatus CommandlineCommandIndex::parse(std::vector<std:
 	else if (vm.count("incomplete"))
 	{
 		m_parser->incompleteRefresh();
+	}
+
+	if (vm.count("shallow"))
+	{
+		m_parser->setShallowIndexingRequested();
 	}
 
 	if (vm.count("project-file"))

--- a/src/lib/utility/messaging/type/MessageLoadProject.h
+++ b/src/lib/utility/messaging/type/MessageLoadProject.h
@@ -10,10 +10,11 @@ class MessageLoadProject: public Message<MessageLoadProject>
 {
 public:
 	MessageLoadProject(
-		const FilePath& filePath, bool settingsChanged = false, RefreshMode refreshMode = REFRESH_NONE)
+		const FilePath& filePath, bool settingsChanged = false, RefreshMode refreshMode = REFRESH_NONE, bool shallowIndexingRequested = false)
 		: projectSettingsFilePath(filePath)
 		, settingsChanged(settingsChanged)
 		, refreshMode(refreshMode)
+		, shallowIndexingRequested(shallowIndexingRequested)
 	{
 	}
 
@@ -32,6 +33,7 @@ public:
 	const FilePath projectSettingsFilePath;
 	const bool settingsChanged;
 	const RefreshMode refreshMode;
+	const bool shallowIndexingRequested;
 };
 
 #endif	  // MESSAGE_LOAD_PROJECT_H


### PR DESCRIPTION
* added "--shallow" command line option to request shallow indexing
* modified behavior of Sourcetrail to always perform a deep index if not explicitly specified differently by the user