### PR TITLE
Replace unsafe http links with https in docs

### DIFF
--- a/docs/documentation/index.html
+++ b/docs/documentation/index.html
@@ -63,7 +63,7 @@
 
 				<div class="col-xs-12 col-sm-3">
 					<div class="row">
-						<p class="backlink"><span class="glyphicon glyphicon-arrow-left"></span> <a href="http://www.sourcetrail.com/">sourcetrail.com</a></p>
+						<p class="backlink"><span class="glyphicon glyphicon-arrow-left"></span> <a href="https://www.sourcetrail.com/">sourcetrail.com</a></p>
 					</div>
 					<div class="row">
 						<div id="toc"></div><!-- Our table of contents will be here !-->
@@ -105,10 +105,10 @@
 
 					<h2>Supported Languages</h2>
 					<h3>C</h3>
-					<p>C support is powered by <a href="http://clang.llvm.org/" target="_blank">Clang 8.0.1</a>. For issues loading C code, please have a look at <a href="http://clang.llvm.org/compatibility.html" target="_blank">Clang language compatibility</a> or report a bug in our <a href="https://github.com/CoatiSoftware/SourcetrailBugTracker">bug tracker</a>.</p>
+					<p>C support is powered by <a href="https://clang.llvm.org/" target="_blank">Clang 8.0.1</a>. For issues loading C code, please have a look at <a href="https://clang.llvm.org/compatibility.html" target="_blank">Clang language compatibility</a> or report a bug in our <a href="https://github.com/CoatiSoftware/SourcetrailBugTracker">bug tracker</a>.</p>
 
 					<h3>C++</h3>
-					<p>C++ support is powered by <a href="http://clang.llvm.org/" target="_blank">Clang 8.0.1</a>. For more Information please visit <a href="http://clang.llvm.org/cxx_status.html" target="_blank">Clang C++ Status</a>. For issues loading C++ code, please have a look at <a href="http://clang.llvm.org/compatibility.html" target="_blank">Clang language compatibility</a> or report a bug in our <a href="https://github.com/CoatiSoftware/SourcetrailBugTracker">bug tracker</a>.</p>
+					<p>C++ support is powered by <a href="https://clang.llvm.org/" target="_blank">Clang 8.0.1</a>. For more Information please visit <a href="https://clang.llvm.org/cxx_status.html" target="_blank">Clang C++ Status</a>. For issues loading C++ code, please have a look at <a href="https://clang.llvm.org/compatibility.html" target="_blank">Clang language compatibility</a> or report a bug in our <a href="https://github.com/CoatiSoftware/SourcetrailBugTracker">bug tracker</a>.</p>
 
 					<h3>Java</h3>
 					<p>Sourcetrail includes support for Java 10 and lower which is powered by <a href="https://github.com/eclipse/eclipse.jdt.core" target="_blank">Eclipse JDT</a>. If you encounter any issues while using Sourcetrail on a Java project, please let us know by providing a minimal example in our <a href="https://github.com/CoatiSoftware/SourcetrailBugTracker">bug tracker</a>.</p>
@@ -3154,7 +3154,7 @@
 							<p>Sourcetrail does two things with the data collected during indexing:</p>
 							<ol>
 								<li>The data is stored in the <code>.srctrldb</code> file which is in the same directory as the <code>.srctrlprj</code> file. This database file is used by Sourcetrail to serve its purpose of letting you navigate your source code and also allowing Sourcetrail to re-open the project without re-indexing the source code each time.
-								<p><b> Note:</b> The <code> .srctrldb </code> file is actualy a <code> .sqlite </code> database file and can be inspected using the <a href="http://https://sqlitebrowser.org/">DB Browser for SQLite</a>.</p>
+								<p><b> Note:</b> The <code> .srctrldb </code> file is actualy a <code> .sqlite </code> database file and can be inspected using the <a href="https://sqlitebrowser.org/">DB Browser for SQLite</a>.</p>
 								</li>
 
 								<li>If logging is enabled, some of the data gets logged into a log file saved in <a href="#Datafolder">data</a>/logs. These logs can be useful to us for fixing bugs. We may ask for log information on bug reports, but you should only provide it, if your source code is not confidental.</li>
@@ -3173,7 +3173,7 @@
 
 					<address>
 						<strong>Contact</strong><br>
-						<a href="http://coati.io">coati.io</a><br>
+						<a href="https://coati.io">coati.io</a><br>
 						<a href="mailto:mail@coati.io" target="_top">mail@coati.io</a><br>
 					</address>
 

--- a/docs/documentation/index.html
+++ b/docs/documentation/index.html
@@ -3173,7 +3173,7 @@
 
 					<address>
 						<strong>Contact</strong><br>
-						<a href="https://coati.io">coati.io</a><br>
+						<a href="http://coati.io">coati.io</a><br>
 						<a href="mailto:mail@coati.io" target="_top">mail@coati.io</a><br>
 					</address>
 


### PR DESCRIPTION
Before merging this change you need to fix the certificate for https://coati.io though :)