### PR TITLE
Fixes build on Gentoo Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,24 +299,18 @@ if (BUILD_CXX_LANGUAGE_PACKAGE)
 	link_directories(${LLVM_LIBRARY_DIRS} ${CLANG_LIBRARY_DIRS} ${Boost_LIBRARY_DIRS})
 
 	llvm_map_components_to_libnames(REQ_LLVM_LIBS
-		support core libdriver passes
-		x86asmparser x86codegen
-		aarch64asmparser aarch64codegen
-		amdgpuasmparser amdgpucodegen
-		armasmparser armcodegen
-		bpfasmparser bpfcodegen
-		hexagonasmparser hexagoncodegen
-		lanaiasmparser lanaicodegen
-		mipsasmparser mipscodegen
-		msp430asmparser msp430codegen
-		nvptxcodegen
-		powerpcasmparser powerpccodegen
-		riscvasmparser riscvcodegen
-		sparcasmparser sparccodegen
-		systemzasmparser systemzcodegen
-		webassemblyasmparser webassemblycodegen
-		xcorecodegen
+		support core libdriver passes option
 	)
+	foreach(LLVM_TARGET ${LLVM_TARGETS_TO_BUILD})
+		get_property(lib_deps GLOBAL PROPERTY "LLVMBUILD_LIB_DEPS_LLVM${LLVM_TARGET}CodeGen")
+		list(APPEND REQ_LLVM_LIBS "LLVM${LLVM_TARGET}CodeGen")
+		list(APPEND REQ_LLVM_LIBS "${lib_deps}")
+		get_property(lib_deps GLOBAL PROPERTY "LLVMBUILD_LIB_DEPS_LLVM${LLVM_TARGET}AsmParser")
+		if (NOT "${lib_deps}" STREQUAL "")
+			list(APPEND REQ_LLVM_LIBS "LLVM${LLVM_TARGET}AsmParser")
+			list(APPEND REQ_LLVM_LIBS "${lib_deps}")
+		endif()
+	endforeach()
 
 	set(CLANG_LIBRARIES
 		clangASTMatchers


### PR DESCRIPTION
Fixes the build on Gentoo Linux. On Gentoo Linux the user chooses which
llvm backend to build and install, therefore we need to loop over the
installed targets and append the libraries needed instead of relying on
the full list of supported backends.