### PR TITLE
perf: GetOverviewBundleNodeTypesOrdered to static const variable.

### DIFF
--- a/src/lib/component/controller/GraphController.cpp
+++ b/src/lib/component/controller/GraphController.cpp
@@ -1433,7 +1433,7 @@ void GraphController::bundleNodesByType()
 
 	bool hasNonFileBundle = false;
 
-	for (const NodeType& nodeType: NodeType::getOverviewBundleNodeTypesOrdered())
+	for (const NodeType& nodeType: NodeType::overviewBundleNodeTypesOrdered)
 	{
 		Tree<NodeType::BundleInfo> bundleInfoTree = nodeType.getOverviewBundleTree();
 		if (bundleInfoTree.data.isValid())

--- a/src/lib/data/NodeType.cpp
+++ b/src/lib/data/NodeType.cpp
@@ -3,7 +3,7 @@
 #include "ResourcePaths.h"
 #include "utilityString.h"
 
-std::array<NodeType, 15> const NodeType::overviewBundleNodeTypesOrdered = 
+std::vector<NodeType> const NodeType::overviewBundleNodeTypesOrdered = 
 {
 	NodeType(NodeType::NODE_FILE),
 	NodeType(NodeType::NODE_MACRO),

--- a/src/lib/data/NodeType.cpp
+++ b/src/lib/data/NodeType.cpp
@@ -3,25 +3,24 @@
 #include "ResourcePaths.h"
 #include "utilityString.h"
 
-std::vector<NodeType> NodeType::getOverviewBundleNodeTypesOrdered()
+std::array<NodeType, 15> const NodeType::overviewBundleNodeTypesOrdered = 
 {
-	return {
-		NodeType(NodeType::NODE_FILE),
-		NodeType(NodeType::NODE_MACRO),
-		NodeType(NodeType::NODE_ANNOTATION),
-		NodeType(NodeType::NODE_MODULE),
-		NodeType(NodeType::NODE_NAMESPACE),
-		NodeType(NodeType::NODE_PACKAGE),
-		NodeType(NodeType::NODE_CLASS),
-		NodeType(NodeType::NODE_INTERFACE),
-		NodeType(NodeType::NODE_STRUCT),
-		NodeType(NodeType::NODE_UNION),
-		NodeType(NodeType::NODE_FUNCTION),
-		NodeType(NodeType::NODE_GLOBAL_VARIABLE),
-		NodeType(NodeType::NODE_TYPE),
-		NodeType(NodeType::NODE_TYPEDEF),
-		NodeType(NodeType::NODE_ENUM)};
-}
+	NodeType(NodeType::NODE_FILE),
+	NodeType(NodeType::NODE_MACRO),
+	NodeType(NodeType::NODE_ANNOTATION),
+	NodeType(NodeType::NODE_MODULE),
+	NodeType(NodeType::NODE_NAMESPACE),
+	NodeType(NodeType::NODE_PACKAGE),
+	NodeType(NodeType::NODE_CLASS),
+	NodeType(NodeType::NODE_INTERFACE),
+	NodeType(NodeType::NODE_STRUCT),
+	NodeType(NodeType::NODE_UNION),
+	NodeType(NodeType::NODE_FUNCTION),
+	NodeType(NodeType::NODE_GLOBAL_VARIABLE),
+	NodeType(NodeType::NODE_TYPE),
+	NodeType(NodeType::NODE_TYPEDEF),
+	NodeType(NodeType::NODE_ENUM)
+};
 
 int NodeType::typeToInt(NodeType::Type type)
 {

--- a/src/lib/data/NodeType.h
+++ b/src/lib/data/NodeType.h
@@ -6,7 +6,6 @@
 #include <memory>
 #include <set>
 #include <vector>
-#include <array>
 
 #include "FilePath.h"
 #include "Tree.h"
@@ -119,7 +118,7 @@ public:
 	std::wstring getUnderscoredTypeWString() const;
 	std::wstring getReadableTypeWString() const;
 
-	static std::array<NodeType, 15> const overviewBundleNodeTypesOrdered;
+	static std::vector<NodeType> const overviewBundleNodeTypesOrdered;
 private:
 	Type m_type;
 };

--- a/src/lib/data/NodeType.h
+++ b/src/lib/data/NodeType.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <set>
 #include <vector>
+#include <array>
 
 #include "FilePath.h"
 #include "Tree.h"
@@ -118,6 +119,7 @@ public:
 	std::wstring getUnderscoredTypeWString() const;
 	std::wstring getReadableTypeWString() const;
 
+	static std::array<NodeType, 15> const overviewBundleNodeTypesOrdered;
 private:
 	Type m_type;
 };


### PR DESCRIPTION
During code review I found potential optimization.
Method getOverviewBundleNodeTypesOrdered is called by function GraphController::bundleNodesByType as vector of enums.
But this is not optimized so in assembly. 

![Screenshot_2020-01-05_01-17-15](https://user-images.githubusercontent.com/11246021/71773652-3d485700-2f58-11ea-92a8-49e9b6ae46ef.png)

and unfortunately:
![Screenshot_2020-01-05_01-18-28](https://user-images.githubusercontent.com/11246021/71773654-4f29fa00-2f58-11ea-9523-c31e322e5dd5.png)

Function by every call constructs whole vector. 

We can fix that situation by eliminating method call and making vector (array) static and const.  
Result after fix:
![Screenshot_2020-01-05_01-14-15](https://user-images.githubusercontent.com/11246021/71773659-88fb0080-2f58-11ea-8466-875286054f74.png)
All tests passed.
