### PR TITLE
perf: Added utilities::caseInsensitiveLess.

### DIFF
--- a/src/lib/component/controller/helper/DummyNode.h
+++ b/src/lib/component/controller/helper/DummyNode.h
@@ -40,7 +40,7 @@ public:
 				return a->isBundleNode();
 			}
 
-			return utility::toLowerCase(a->name) < utility::toLowerCase(b->name);
+			return utility::caseInsensitiveLess(a->name, b->name);
 		}
 	};
 

--- a/src/lib_utility/utility/utilityString.cpp
+++ b/src/lib_utility/utility/utilityString.cpp
@@ -622,4 +622,27 @@ std::wstring convertWhiteSpacesToSingleSpaces(const std::wstring& str)
 
 	return join<std::deque<std::wstring>>(parts, L" ");
 }
+
+bool caseInsensitiveLess(const std::wstring& s1, const std::wstring& s2)
+{
+	size_t s1_size = s1.size();
+	size_t s2_size = s2.size();
+	bool res_cmp = s1_size < s2_size; 
+	size_t lesser_size = s2_size ^ ((s1_size ^ s2_size) & -res_cmp);
+	for (size_t i = 0; i < lesser_size; ++i)
+	{
+		wchar_t s1_wchr = s1[i];
+		wchar_t s2_wchr = s2[i];
+		if (s1_wchr != s2_wchr)
+		{
+			s1_wchr = towlower(s1_wchr);
+			s2_wchr = towlower(s2_wchr);
+			if (s1_wchr != s2_wchr)
+			{
+				return s1_wchr < s2_wchr;
+			}
+		}
+	}
+	return res_cmp;
+}
 }	 // namespace utility

--- a/src/lib_utility/utility/utilityString.h
+++ b/src/lib_utility/utility/utilityString.h
@@ -99,6 +99,8 @@ std::wstring elide(const std::wstring& str, ElideMode mode, size_t size);
 
 std::wstring convertWhiteSpacesToSingleSpaces(const std::wstring& str);
 
+bool caseInsensitiveLess(const std::wstring& s1, const std::wstring& s2);
+
 template <typename ContainerType>
 ContainerType split(const std::string& str, const std::string& delimiter)
 {

--- a/src/test/UtilityStringTestSuite.cpp
+++ b/src/test/UtilityStringTestSuite.cpp
@@ -300,3 +300,48 @@ TEST_CASE("replace")
 	REQUIRE("" == utility::replace("", "foo", "bar"));
 	REQUIRE("foobar" == utility::replace("foobar", "ba", "ba"));
 }
+
+TEST_CASE("caseInsensitiveLess should return false when comparing empty wstrings")
+{
+	REQUIRE_FALSE(utility::caseInsensitiveLess(L"", L""));
+}
+
+TEST_CASE("caseInsensitiveLess should return false when both wstrings are equal")
+{
+	REQUIRE_FALSE(utility::caseInsensitiveLess(L"ab_cd!", L"ab_cd!"));
+}
+
+TEST_CASE("caseInsensitiveLess should return true when first wstring is empty and second not")
+{
+	REQUIRE(utility::caseInsensitiveLess(L"", L"ab"));
+}
+
+TEST_CASE("caseInsensitiveLess should return false when first wstring is filled and second not")
+{
+	REQUIRE_FALSE(utility::caseInsensitiveLess(L"ab", L""));
+}
+
+TEST_CASE("caseInsensitiveLess should return true when first wstring is prefix of second")
+{
+	REQUIRE(utility::caseInsensitiveLess(L"ab_cd!", L"ab_cd!e"));
+}
+
+TEST_CASE("caseInsensitiveLess should return true when second wstring is prefix of first")
+{
+	REQUIRE_FALSE(utility::caseInsensitiveLess(L"ab_cd!e", L"ab_cd!"));
+}
+
+TEST_CASE("caseInsensitiveLess should return true when after lower casing first wstring is prefix of second")
+{
+	REQUIRE(utility::caseInsensitiveLess(L"aB_cd!", L"ab_cd!e"));
+}
+
+TEST_CASE("caseInsensitiveLess should return true when after lower casing second wstring, first is prefix of second")
+{
+	REQUIRE(utility::caseInsensitiveLess(L"aB_cd!", L"ab_cd!e"));
+}
+
+TEST_CASE("caseInsensitiveLess should return true when after lower casing both wstrings, first is prefix of second")
+{
+	REQUIRE(utility::caseInsensitiveLess(L"aB_cd!", L"ab_cD!E"));
+}

--- a/src/test/UtilityStringTestSuite.cpp
+++ b/src/test/UtilityStringTestSuite.cpp
@@ -311,12 +311,18 @@ TEST_CASE("caseInsensitiveLess should return false when both wstrings are equal"
 	REQUIRE_FALSE(utility::caseInsensitiveLess(L"ab_cd!", L"ab_cd!"));
 }
 
+TEST_CASE("caseInsensitiveLess should return false when both wstrings have"
+		"different cases but after lower casing are equal")
+{
+	REQUIRE_FALSE(utility::caseInsensitiveLess(L"ab_CD!", L"aB_cD!"));
+}
+
 TEST_CASE("caseInsensitiveLess should return true when first wstring is empty and second not")
 {
 	REQUIRE(utility::caseInsensitiveLess(L"", L"ab"));
 }
 
-TEST_CASE("caseInsensitiveLess should return false when first wstring is filled and second not")
+TEST_CASE("caseInsensitiveLess should return false when second wstring is empty and first not")
 {
 	REQUIRE_FALSE(utility::caseInsensitiveLess(L"ab", L""));
 }
@@ -326,22 +332,37 @@ TEST_CASE("caseInsensitiveLess should return true when first wstring is prefix o
 	REQUIRE(utility::caseInsensitiveLess(L"ab_cd!", L"ab_cd!e"));
 }
 
-TEST_CASE("caseInsensitiveLess should return true when second wstring is prefix of first")
+TEST_CASE("caseInsensitiveLess should return false when second wstring is prefix of first")
 {
 	REQUIRE_FALSE(utility::caseInsensitiveLess(L"ab_cd!e", L"ab_cd!"));
 }
 
-TEST_CASE("caseInsensitiveLess should return true when after lower casing first wstring is prefix of second")
+TEST_CASE("caseInsensitiveLess should return true when after lower casing first wstring, first is prefix of second")
 {
 	REQUIRE(utility::caseInsensitiveLess(L"aB_cd!", L"ab_cd!e"));
 }
 
 TEST_CASE("caseInsensitiveLess should return true when after lower casing second wstring, first is prefix of second")
 {
-	REQUIRE(utility::caseInsensitiveLess(L"aB_cd!", L"ab_cd!e"));
+	REQUIRE(utility::caseInsensitiveLess(L"ab_cd!", L"ab_cD!e"));
 }
 
 TEST_CASE("caseInsensitiveLess should return true when after lower casing both wstrings, first is prefix of second")
 {
 	REQUIRE(utility::caseInsensitiveLess(L"aB_cd!", L"ab_cD!E"));
+}
+
+TEST_CASE("caseInsensitiveLess should return false when after lower casing first wstring, second is prefix of first")
+{
+	REQUIRE_FALSE(utility::caseInsensitiveLess(L"ab_Cd!e", L"ab_cd!"));
+}
+
+TEST_CASE("caseInsensitiveLess should return false when after lower casing second wstring, second is prefix of first")
+{
+	REQUIRE_FALSE(utility::caseInsensitiveLess(L"ab_cd!e", L"Ab_cd!"));
+}
+
+TEST_CASE("caseInsensitiveLess should return false when after lower casing both wstrings, second is prefix of first")
+{
+	REQUIRE_FALSE(utility::caseInsensitiveLess(L"ab_cD!E", L"aB_cd!"));
 }


### PR DESCRIPTION
Another performance improvement. This one is very impactful and improvement is quite noticeable.
 
It replaces two function calls utilities::toLowerCase and std::compare (by operator<).
Problem with old way was creating two additional strings every time when  DummyNodeComp function operator() was called (which is very often) and then making comparison.
New function utilities::caseInsensitiveLess do same logic but in place.
For this example data:
```
std::wstring str1 = L"1aaBcssdef";
std::wstring str2 = L"1aAbcssdefg_hijkds";
```
I've done benchmark by extraction utilities::toLowerCase implementation and comparison with utilities::caseInsensitiveLess. Test measured on Debian buster
with Intel(R) Core(TM) i5-8250U CPU @ 1.60GHz.
Benchmark done on single isolated core with max scheduler priority.
Results of single core reference cycles at tsc rate:

utilities::toLowerCase way | utilities::caseInsensitiveLess way
------------------------------------- | --------------------------------------------
13050 | 600
13275 | 600
13050 | 600

Perf benchmark collected on linux-5.4.7 database.
Procedure to reproduce:
1. download linux-5.4.7 source code and bear
2. make tinyconfig
3. bear make -j <nb of your cores>
4. start sourcetrail 
5. create database from compile_commands.json
6. restart sourcetrail
7. perf record -g -p <pid of sourcetrail>
8. load linux-5.4.7 database
9. stop recording after finished loading and graph visualization

On master branch:
![Screenshot_2020-01-06_15-55-24](https://user-images.githubusercontent.com/11246021/71841701-ef4a6500-30b7-11ea-848b-526588b4ef70.png)

After fix:
![Screenshot_2020-01-06_19-28-56](https://user-images.githubusercontent.com/11246021/71842340-4ac92280-30b9-11ea-8bc0-663ff841682c.png)

After fix there is ~6s faster load (linux-5.4.7 database).
