### PR TITLE
perf: PersistentStorage::getGraphForAll - avoiding second sqlite call.

### DIFF
--- a/src/lib/data/storage/PersistentStorage.cpp
+++ b/src/lib/data/storage/PersistentStorage.cpp
@@ -1024,35 +1024,69 @@ std::shared_ptr<Graph> PersistentStorage::getGraphForAll() const
 {
 	TRACE();
 
-	std::vector<Id> tokenIds;
-
-	m_sqliteIndexStorage.forEach<StorageNode>([&](StorageNode&& node) {
-		bool showNode = true;
-		if (m_symbolDefinitionKinds.size())
-		{
-			auto it = m_symbolDefinitionKinds.find(node.id);
-			showNode = (it != m_symbolDefinitionKinds.end() && it->second == DEFINITION_EXPLICIT);
-		}
-
-		if (showNode &&
-			(NodeType(NodeType::intToType(node.type)).isPackage() ||
-			 !m_hierarchyCache.isChildOfVisibleNodeOrInvisible(node.id)))
-		{
-			tokenIds.push_back(node.id);
-		}
-	});
-
-	for (const auto& p: m_fileNodeIndexed)
-	{
-		if (p.second)
-		{
-			tokenIds.push_back(p.first);
-		}
-	}
-
 	std::shared_ptr<Graph> graph = std::make_shared<Graph>();
-	addNodesToGraph(tokenIds, graph.get(), false);
+	if (m_symbolDefinitionKinds.size()) {
+		m_sqliteIndexStorage.forEach<StorageNode>([&](StorageNode&& storageNode) {
+			const NodeType type(NodeType::intToType(storageNode.type));
+			if (type.isFile())
+			{
+				NameHierarchy nameHierarchy = NameHierarchy::deserialize(storageNode.serializedName);
+				const FilePath filePath(nameHierarchy.getRawName());
 
+				bool complete = getFileNodeComplete(storageNode.id);
+				bool indexed = getFileNodeIndexed(storageNode.id);
+
+				Node* node = graph->createNode(
+					storageNode.id,
+					type,
+					NameHierarchy(filePath.fileName(), NAME_DELIMITER_FILE),
+					indexed ? DEFINITION_EXPLICIT : DEFINITION_NONE
+				);
+				node->addComponent(std::make_shared<TokenComponentFilePath>(filePath, complete));
+			}
+			else
+			{
+				auto sdk_it = m_symbolDefinitionKinds.find(storageNode.id);
+				bool showNode = (sdk_it != m_symbolDefinitionKinds.end() && sdk_it->second == DEFINITION_EXPLICIT);
+				if (showNode && (
+					type.isPackage() || 
+					!m_hierarchyCache.isChildOfVisibleNodeOrInvisible(storageNode.id)
+					)
+				)
+				{
+					NameHierarchy nameHierarchy = NameHierarchy::deserialize(storageNode.serializedName);
+					graph->createNode(storageNode.id, type, std::move(nameHierarchy), DEFINITION_EXPLICIT);
+				}
+			}
+		});
+	}
+	else 
+	{
+		m_sqliteIndexStorage.forEach<StorageNode>([&](StorageNode&& storageNode) {
+			const NodeType type(NodeType::intToType(storageNode.type));
+			if (type.isFile())
+			{
+				NameHierarchy nameHierarchy = NameHierarchy::deserialize(storageNode.serializedName);
+				const FilePath filePath(nameHierarchy.getRawName());
+
+				bool complete = getFileNodeComplete(storageNode.id);
+				bool indexed = getFileNodeIndexed(storageNode.id);
+
+				Node* node = graph->createNode(
+					storageNode.id,
+					type,
+					NameHierarchy(filePath.fileName(), NAME_DELIMITER_FILE),
+					indexed ? DEFINITION_EXPLICIT : DEFINITION_NONE
+				);
+				node->addComponent(std::make_shared<TokenComponentFilePath>(filePath, complete));
+			}
+			else if (type.isPackage() || !m_hierarchyCache.isChildOfVisibleNodeOrInvisible(storageNode.id))
+			{
+				NameHierarchy nameHierarchy = NameHierarchy::deserialize(storageNode.serializedName);
+				graph->createNode(storageNode.id, type, std::move(nameHierarchy), DEFINITION_EXPLICIT);
+			}
+		});
+	}
 	return graph;
 }
 

--- a/src/lib/data/storage/PersistentStorage.h
+++ b/src/lib/data/storage/PersistentStorage.h
@@ -241,6 +241,7 @@ private:
 		const std::vector<Id>& edgeIds,
 		Graph* graphh,
 		bool addChildCount) const;
+	inline void addFileNodeToGraph(const StorageNode& storageNode, Graph* const graph) const;
 
 	void addAggregationEdgesToGraph(
 		Id nodeId, const std::vector<StorageEdge>& edgesToAggregate, Graph* graph) const;

--- a/src/lib/data/storage/PersistentStorage.h
+++ b/src/lib/data/storage/PersistentStorage.h
@@ -242,7 +242,7 @@ private:
 		Graph* graphh,
 		bool addChildCount) const;
 	inline void addFileNodeToGraph(const StorageNode& storageNode, Graph* const graph) const;
-
+	void addNodeToGraph(const StorageNode& newNode, const NodeType& type, Graph* graph, bool addChildCount) const;
 	void addAggregationEdgesToGraph(
 		Id nodeId, const std::vector<StorageEdge>& edgesToAggregate, Graph* graph) const;
 	void addFileContentsToGraph(Id fileId, Graph* graph) const;
@@ -277,7 +277,7 @@ private:
 	std::map<FilePath, Id> m_lowerCasefileNodeIds;
 	std::map<Id, FilePath> m_fileNodePaths;
 	std::map<Id, bool> m_fileNodeComplete;
-	std::map<Id, bool> m_fileNodeIndexed;
+	std::unordered_map<Id, bool> m_fileNodeIndexed;
 	std::map<Id, std::wstring> m_fileNodeLanguage;
 
 	std::unordered_map<Id, DefinitionKind> m_symbolDefinitionKinds;

--- a/src/lib/data/storage/PersistentStorage.h
+++ b/src/lib/data/storage/PersistentStorage.h
@@ -279,7 +279,7 @@ private:
 	std::map<Id, bool> m_fileNodeIndexed;
 	std::map<Id, std::wstring> m_fileNodeLanguage;
 
-	std::map<Id, DefinitionKind> m_symbolDefinitionKinds;
+	std::unordered_map<Id, DefinitionKind> m_symbolDefinitionKinds;
 	std::map<Id, Id> m_memberEdgeIdOrderMap;
 
 	HierarchyCache m_hierarchyCache;


### PR DESCRIPTION
Overview graph performance improvement.
Method PersistenceStorage::getGraphForAll calls sqlliteIndexStorage two times:
1. During gathering of node ID's
2. When adding nodes to graph within PersistenceStorage::addNodesToGraph. 

Unfortunately during each of these calls all nodes are retrieved from database.
I rewritten this function. Merging logic from getGraphForAll and addNodesToGraph we can avoid second sql enumeration.
This operation gave me possibility to introduce additional optimizations e.g deletion of redundant checks and avoiding m_fileNodeIndexed enumeration.
Improvement in cycles is aprox. 8% - 15%.
Perf after load project, on debug build,  database linux-5.4.7 before improvement:
![Screenshot_2020-01-12_20-52-26](https://user-images.githubusercontent.com/11246021/72224751-bd347980-3575-11ea-8682-dfcea120aa60.png)

After improvement:
![Screenshot_2020-01-12_20-41-02](https://user-images.githubusercontent.com/11246021/72224741-ab52d680-3575-11ea-900b-a02944b2ce0e.png)

There is a possible removal of redundancy with `if (m_symbolDefinitionKinds.size()) {`
and a little bit performance to gain with answer to question: 
Is there a way that this condition is evaluated as false?