### PR TITLE
logic: fix crash when project directory contains non-latin character (issue #899)

### DIFF
--- a/src/lib/utility/file/FilePath.h
+++ b/src/lib/utility/file/FilePath.h
@@ -31,6 +31,7 @@ public:
 	bool recheckExists() const;
 	bool isDirectory() const;
 	bool isAbsolute() const;
+	bool isValid() const;
 
 	FilePath getParentDirectory() const;
 

--- a/src/lib_gui/qt/project_wizard/content/QtProjectWizardContentProjectData.cpp
+++ b/src/lib_gui/qt/project_wizard/content/QtProjectWizardContentProjectData.cpp
@@ -109,11 +109,30 @@ bool QtProjectWizardContentProjectData::check()
 
 	std::vector<FilePath> paths =
 		FilePath(m_projectFileLocation->getText().toStdWString()).expandEnvironmentVariables();
-	if (paths.size() != 1 || !paths[0].isAbsolute())
+	if (paths.size() != 1)
 	{
 		QMessageBox msgBox;
 		msgBox.setText(
-			"The specified location is invalid. Please enter an absolute directory path.");
+			"The specified location seems to be invalid. Please make sure that the used "
+			"environment variables are unambiguous.");
+		msgBox.exec();
+		return false;
+	}
+	else if (!paths.front().isAbsolute())
+	{
+		QMessageBox msgBox;
+		msgBox.setText(
+			"The specified location seems to be invalid. Please specify an absolute directory "
+			"path.");
+		msgBox.exec();
+		return false;
+	}
+	else if (!paths.front().isValid())
+	{
+		QMessageBox msgBox;
+		msgBox.setText(
+			"The specified location seems to be invalid. Please check the characters used in the "
+			"path.");
 		msgBox.exec();
 		return false;
 	}


### PR DESCRIPTION
* added "isValid" to FilePath
* used "isValid" in check of selected project directory