### PR TITLE
Fixing a crash in FilePath::exists

### DIFF
--- a/src/lib/utility/file/FilePath.cpp
+++ b/src/lib/utility/file/FilePath.cpp
@@ -80,7 +80,7 @@ bool FilePath::empty() const
 	return m_path->empty();
 }
 
-bool FilePath::exists() const
+bool FilePath::exists() const noexcept
 {
 	if (!m_checkedExists)
 	{

--- a/src/lib/utility/file/FilePath.h
+++ b/src/lib/utility/file/FilePath.h
@@ -27,7 +27,7 @@ public:
 	boost::filesystem::path getPath() const;
 
 	bool empty() const;
-	bool exists() const;
+	bool exists() const noexcept;
 	bool recheckExists() const;
 	bool isDirectory() const;
 	bool isAbsolute() const;


### PR DESCRIPTION
Making FilePath::exists noexcept so the noexcept version of boost::filesystem::exists is used. Fixing a crash I ran into.