### PR TITLE
ui: Fixes related to focus navigation

### DIFF
--- a/src/lib/component/controller/CodeController.cpp
+++ b/src/lib/component/controller/CodeController.cpp
@@ -913,6 +913,7 @@ std::vector<std::string> CodeController::getProjectDescription(SourceLocationFil
 	std::vector<std::string> lines = utility::splitToVector(description, "\\n");
 	size_t startLineNumber = 2;
 
+	Id locationId = 0;
 	for (size_t i = 0; i < lines.size(); i++)
 	{
 		std::string line = "\t" + utility::trim(lines[i]);
@@ -943,7 +944,7 @@ std::vector<std::string> CodeController::getProjectDescription(SourceLocationFil
 				line.replace(posA, posB - posA + 1, nameString);
 				locationFile->addSourceLocation(
 					LOCATION_TOKEN,
-					0,
+					++locationId,
 					{tokenId},
 					startLineNumber + i,
 					posA + 1,

--- a/src/lib_gui/qt/element/code/QtCodeArea.cpp
+++ b/src/lib_gui/qt/element/code/QtCodeArea.cpp
@@ -300,6 +300,11 @@ int QtCodeArea::lineNumberAreaWidth() const
 	return 0;
 }
 
+int QtCodeArea::lineHeight() const
+{
+	return static_cast<int>(blockBoundingRect(firstVisibleBlock()).height());
+}
+
 void QtCodeArea::updateLineNumberAreaWidthForDigits(int digits)
 {
 	m_digits = digits;

--- a/src/lib_gui/qt/element/code/QtCodeArea.cpp
+++ b/src/lib_gui/qt/element/code/QtCodeArea.cpp
@@ -19,6 +19,7 @@
 #include "ApplicationSettings.h"
 #include "ColorScheme.h"
 #include "MessageActivateLocalSymbols.h"
+#include "MessageActivateTokenIds.h"
 #include "MessageFocusIn.h"
 #include "MessageFocusOut.h"
 #include "MessageMoveIDECursor.h"
@@ -1060,7 +1061,19 @@ void QtCodeArea::activateAnnotationsOrErrors(
 		}
 	}
 
-	activateAnnotations(annotations, fromMouse, lineNumberAreaWidth());
+	if (!m_showLineNumbers)	// for links in project description
+	{
+		std::set<Id> tokenIds;
+		for (const Annotation* annotation: annotations)
+		{
+			tokenIds.insert(annotation->tokenIds.begin(), annotation->tokenIds.end());
+		}
+		MessageActivateTokenIds(utility::toVector(tokenIds)).dispatch();
+	}
+	else
+	{
+		activateAnnotations(annotations, fromMouse, lineNumberAreaWidth());
+	}
 }
 
 void QtCodeArea::focusAnnotation(const Annotation* annotation, bool updateTargetColumn, bool fromMouse)

--- a/src/lib_gui/qt/element/code/QtCodeArea.h
+++ b/src/lib_gui/qt/element/code/QtCodeArea.h
@@ -63,6 +63,7 @@ public:
 	void lineNumberAreaPaintEvent(QPaintEvent* event);
 	int lineNumberDigits() const;
 	int lineNumberAreaWidth() const;
+	int lineHeight() const;
 	void updateLineNumberAreaWidthForDigits(int digits);
 
 	void updateSourceLocations(std::shared_ptr<SourceLocationFile> locationFile);

--- a/src/lib_gui/qt/element/code/QtCodeField.cpp
+++ b/src/lib_gui/qt/element/code/QtCodeField.cpp
@@ -10,7 +10,6 @@
 #include "ColorScheme.h"
 #include "MessageActivateLocalSymbols.h"
 #include "MessageActivateSourceLocations.h"
-#include "MessageActivateTokenIds.h"
 #include "MessageTabOpenWith.h"
 #include "MessageTooltipShow.h"
 #include "QtContextMenu.h"
@@ -561,10 +560,6 @@ void QtCodeField::activateAnnotations(
 	else if (locationIds.size())
 	{
 		MessageActivateSourceLocations(locationIds, containsUnsolved).dispatch();
-	}
-	else if (tokenIds.size())	 // fallback for links in project description
-	{
-		MessageActivateTokenIds(utility::toVector(tokenIds)).dispatch();
 	}
 	else if (localSymbolIds.size())
 	{

--- a/src/lib_gui/qt/element/code/QtCodeNavigator.cpp
+++ b/src/lib_gui/qt/element/code/QtCodeNavigator.cpp
@@ -721,27 +721,73 @@ void QtCodeNavigator::keyPressEvent(QKeyEvent* event)
 		}
 	};
 
+	auto moveView = [=](CodeFocusHandler::Direction direction) {
+		if (!alt && !shift && ctrl)
+		{
+			QAbstractScrollArea* scrollArea = currentFocus.area;
+			int step = currentFocus.area ? currentFocus.area->lineHeight() * 3 : 50;
+			if (direction == CodeFocusHandler::Direction::DOWN || direction == CodeFocusHandler::Direction::UP)
+			{
+				if (m_mode == MODE_LIST)
+				{
+					scrollArea = m_list->getScrollArea();
+				}
+				else
+				{
+					step = 3;
+				}
+			}
+
+			if (scrollArea)
+			{
+				QScrollBar* horizontalScrollBar = scrollArea->horizontalScrollBar();
+				QScrollBar* verticalScrollBar = scrollArea->verticalScrollBar();
+
+				if (direction == CodeFocusHandler::Direction::DOWN)
+				{
+					verticalScrollBar->setValue(verticalScrollBar->value() + step);
+				}
+				else if (direction == CodeFocusHandler::Direction::UP)
+				{
+					verticalScrollBar->setValue(verticalScrollBar->value() - step);
+				}
+				else if (direction == CodeFocusHandler::Direction::RIGHT)
+				{
+					horizontalScrollBar->setValue(horizontalScrollBar->value() + step);
+				}
+				else if (direction == CodeFocusHandler::Direction::LEFT)
+				{
+					horizontalScrollBar->setValue(horizontalScrollBar->value() - step);
+				}
+			}
+		}
+	};
+
 	switch (event->key())
 	{
 	case Qt::Key_Up:
+		moveView(CodeFocusHandler::Direction::UP);
 	case Qt::Key_K:
 	case Qt::Key_W:
 		moveFocus(CodeFocusHandler::Direction::UP);
 		break;
 
 	case Qt::Key_Down:
+		moveView(CodeFocusHandler::Direction::DOWN);
 	case Qt::Key_J:
 	case Qt::Key_S:
 		moveFocus(CodeFocusHandler::Direction::DOWN);
 		break;
 
 	case Qt::Key_Left:
+		moveView(CodeFocusHandler::Direction::LEFT);
 	case Qt::Key_H:
 	case Qt::Key_A:
 		moveFocus(CodeFocusHandler::Direction::LEFT);
 		break;
 
 	case Qt::Key_Right:
+		moveView(CodeFocusHandler::Direction::RIGHT);
 	case Qt::Key_L:
 	case Qt::Key_D:
 		moveFocus(CodeFocusHandler::Direction::RIGHT);

--- a/src/lib_gui/qt/graphics/QtGraphicsView.cpp
+++ b/src/lib_gui/qt/graphics/QtGraphicsView.cpp
@@ -316,32 +316,39 @@ void QtGraphicsView::keyPressEvent(QKeyEvent* event)
 	switch (event->key())
 	{
 	case Qt::Key_Up:
-	case Qt::Key_K:
-	case Qt::Key_W:
-		if (alt)
+		if (ctrl && !alt)
 		{
 			m_up = true;
+			break;
 		}
-		else if (!ctrl)
+	case Qt::Key_K:
+	case Qt::Key_W:
+		if (!ctrl && !alt)
 		{
 			m_focusHandler->focusNext(GraphFocusHandler::Direction::UP, shift);
 		}
 		break;
 
 	case Qt::Key_Down:
-	case Qt::Key_J:
-	case Qt::Key_S:
-		if (alt)
+		if (ctrl && !alt)
 		{
 			m_down = true;
+			break;
 		}
-		else if (!ctrl)
+	case Qt::Key_J:
+	case Qt::Key_S:
+		if (!alt && !ctrl)
 		{
 			m_focusHandler->focusNext(GraphFocusHandler::Direction::DOWN, shift);
 		}
 		break;
 
 	case Qt::Key_Left:
+		if (ctrl && !shift && !alt)
+		{
+			m_left = true;
+			break;
+		}
 	case Qt::Key_H:
 	case Qt::Key_A:
 		if (!alt && !ctrl)
@@ -351,6 +358,11 @@ void QtGraphicsView::keyPressEvent(QKeyEvent* event)
 		break;
 
 	case Qt::Key_Right:
+		if (ctrl && !shift && !alt)
+		{
+			m_right = true;
+			break;
+		}
 	case Qt::Key_L:
 	case Qt::Key_D:
 		if (!alt && !ctrl)
@@ -394,8 +406,11 @@ void QtGraphicsView::keyPressEvent(QKeyEvent* event)
 		setZoomFactor(1.0f);
 		updateTransform();
 		break;
-	case Qt::Key_Alt:
-		m_alt = true;
+	case Qt::Key_Shift:
+		m_shift = true;
+		break;
+	case Qt::Key_Control:
+		m_ctrl = true;
 		break;
 	default:
 		QGraphicsView::keyPressEvent(event);
@@ -414,14 +429,25 @@ void QtGraphicsView::keyReleaseEvent(QKeyEvent* event)
 {
 	switch (event->key())
 	{
+	case Qt::Key_Up:
 	case Qt::Key_W:
 		m_up = false;
 		break;
+	case Qt::Key_Down:
 	case Qt::Key_S:
 		m_down = false;
 		break;
-	case Qt::Key_Alt:
-		m_alt = false;
+	case Qt::Key_Left:
+		m_left = false;
+		break;
+	case Qt::Key_Right:
+		m_right = false;
+		break;
+	case Qt::Key_Shift:
+		m_shift = false;
+		break;
+	case Qt::Key_Control:
+		m_ctrl = false;
 		break;
 	default:
 		return;
@@ -579,9 +605,14 @@ void QtGraphicsView::focusOutEvent(QFocusEvent* event)
 
 void QtGraphicsView::updateTimer()
 {
+	const float ds = 30.0f;
 	const float dz = 50.0f;
 
-	if (m_alt)
+	float x = 0.0f;
+	float y = 0.0f;
+	float z = 0.0f;
+
+	if (m_shift && m_ctrl)
 	{
 		if (m_up)
 		{
@@ -591,6 +622,36 @@ void QtGraphicsView::updateTimer()
 		{
 			updateZoom(-dz);
 		}
+	}
+	else if (m_ctrl)
+	{
+		if (m_up)
+		{
+			y -= ds;
+		}
+		else if (m_down)
+		{
+			y += ds;
+		}
+
+		if (m_left)
+		{
+			x -= ds;
+		}
+		else if (m_right)
+		{
+			x += ds;
+		}
+	}
+
+	if (x != 0)
+	{
+		horizontalScrollBar()->setValue(horizontalScrollBar()->value() + x);
+	}
+
+	if (y != 0)
+	{
+		verticalScrollBar()->setValue(verticalScrollBar()->value() + y);
 	}
 }
 
@@ -748,7 +809,7 @@ void QtGraphicsView::legendClicked()
 
 bool QtGraphicsView::moves() const
 {
-	return m_up || m_down;
+	return m_up || m_down || m_left || m_right;
 }
 
 void QtGraphicsView::setZoomFactor(float zoomFactor)

--- a/src/lib_gui/qt/graphics/QtGraphicsView.cpp
+++ b/src/lib_gui/qt/graphics/QtGraphicsView.cpp
@@ -605,12 +605,11 @@ void QtGraphicsView::focusOutEvent(QFocusEvent* event)
 
 void QtGraphicsView::updateTimer()
 {
-	const float ds = 30.0f;
+	const int ds = 30;
 	const float dz = 50.0f;
 
-	float x = 0.0f;
-	float y = 0.0f;
-	float z = 0.0f;
+	int x = 0;
+	int y = 0;
 
 	if (m_shift && m_ctrl)
 	{

--- a/src/lib_gui/qt/graphics/QtGraphicsView.h
+++ b/src/lib_gui/qt/graphics/QtGraphicsView.h
@@ -97,7 +97,11 @@ private:
 
 	bool m_up = false;
 	bool m_down = false;
-	bool m_alt = false;
+	bool m_left = false;
+	bool m_right = false;
+
+	bool m_shift = false;
+	bool m_ctrl = false;
 
 	std::wstring m_clipboardNodeName;
 	Id m_openInTabNodeId;

--- a/src/lib_gui/qt/graphics/graph/QtGraphNode.cpp
+++ b/src/lib_gui/qt/graphics/graph/QtGraphNode.cpp
@@ -277,6 +277,8 @@ void QtGraphNode::setIsFocused(bool focused)
 		{
 			coFocusOut();
 		}
+
+		updateStyle();
 	}
 }
 

--- a/src/lib_gui/qt/view/QtGraphView.cpp
+++ b/src/lib_gui/qt/view/QtGraphView.cpp
@@ -414,9 +414,13 @@ void QtGraphView::rebuildGraph(
 		{
 			m_focusHandler.focusTokenId(m_nodes, m_edges, params.tokenIdToFocus);
 		}
-		else
+		else if (hasNavigationFocus())
 		{
 			m_focusHandler.refocusNode(m_nodes, oldActiveTokenId, newActiveTokenId);
+		}
+		else
+		{
+			m_focusHandler.clear();
 		}
 
 		m_centerActiveNode = params.centerActiveNode;

--- a/src/lib_gui/qt/window/QtKeyboardShortcuts.cpp
+++ b/src/lib_gui/qt/window/QtKeyboardShortcuts.cpp
@@ -267,13 +267,17 @@ QTableWidget* QtKeyboardShortcuts::createGraphViewShortcutsTable()
 			 QStringLiteral("Ctrl + Shift + Enter | Ctrl + Shift + E"),
 			 QStringLiteral("Cmd + Shift + Enter | Cmd + Shift + E")),
 		 Shortcut::defaultOrMac(
+			 QStringLiteral("Scroll Graph Area"),
+			 QStringLiteral("Ctrl + Arrows"),
+			 QStringLiteral("Cmd + Arrows")),
+		 Shortcut::defaultOrMac(
 			 QStringLiteral("Zoom in"),
-			 QStringLiteral("Alt + W | Ctrl + Mousewheel up"),
-			 QStringLiteral("Alt + W | Cmd + Mousewheel up")),
+			 QStringLiteral("Ctrl + Shift + Up | Ctrl + Mousewheel up"),
+			 QStringLiteral("Cmd + Shift + Up | Cmd + Mousewheel up")),
 		 Shortcut::defaultOrMac(
 			 QStringLiteral("Zoom out"),
-			 QStringLiteral("Alt + S | Ctrl + Mousewheel down"),
-			 QStringLiteral("Alt + S | Cmd + Mousewheel down")),
+			 QStringLiteral("Ctrl + Shift + Down | Ctrl + Mousewheel down"),
+			 QStringLiteral("Cmd + Shift + Down | Cmd + Mousewheel down")),
 		 Shortcut(QStringLiteral("Reset Zoom"), QStringLiteral("0")),
 		 Shortcut::defaultOrMac(
 			 QStringLiteral("Open Custom Trail Dialog"),

--- a/src/lib_gui/qt/window/QtKeyboardShortcuts.cpp
+++ b/src/lib_gui/qt/window/QtKeyboardShortcuts.cpp
@@ -241,7 +241,11 @@ QTableWidget* QtKeyboardShortcuts::createCodeViewShortcutsTable()
 		 Shortcut::defaultOrMac(
 			 QStringLiteral("Previous Local Reference"),
 			 QStringLiteral("Ctrl + Shift + L"),
-			 QStringLiteral("Cmd + Shift + L"))});
+			 QStringLiteral("Cmd + Shift + L")),
+		 Shortcut::defaultOrMac(
+			 QStringLiteral("Scroll Code Area"),
+			 QStringLiteral("Ctrl + Arrows"),
+			 QStringLiteral("Cmd + Arrows"))});
 
 	return table;
 }

--- a/src/lib_gui/qt/window/QtMainWindow.cpp
+++ b/src/lib_gui/qt/window/QtMainWindow.cpp
@@ -931,7 +931,7 @@ void QtMainWindow::setupEditMenu()
 	menu->addSeparator();
 
 	menu->addAction(
-		tr("&To overview"), this, &QtMainWindow::overview, QKeySequence::MoveToStartOfDocument);
+		tr("&To overview"), this, &QtMainWindow::overview, QKeySequence(Qt::CTRL + Qt::Key_Home));
 
 	menu->addSeparator();
 


### PR DESCRIPTION
* Scroll graph area with Ctrl + Arrows
* Moved graph zoom to Ctrl + Shift + Up/Down
* Scroll code area with Ctrl + Arrows
* Fixed graph showing focus when activating the active symbol
* Made links in project description focusable
* Fixed parent graph node not showing focus after hovering edge to child node