### PR TITLE
logic: Fixed multiple main declarations not shown as separate symbols when declaring file has same name

### DIFF
--- a/src/lib_cxx/data/parser/cxx/CanonicalFilePathCache.cpp
+++ b/src/lib_cxx/data/parser/cxx/CanonicalFilePathCache.cpp
@@ -121,19 +121,23 @@ Id CanonicalFilePathCache::getFileSymbolId(const std::wstring& path)
 	return 0;
 }
 
-std::wstring CanonicalFilePathCache::getDeclarationFileName(const clang::Decl* declaration)
+FilePath CanonicalFilePathCache::getDeclarationFilePath(const clang::Decl* declaration)
 {
 	const clang::SourceManager& sourceManager = declaration->getASTContext().getSourceManager();
 	const clang::FileID fileId = sourceManager.getFileID(declaration->getBeginLoc());
 	const clang::FileEntry* fileEntry = sourceManager.getFileEntryForID(fileId);
 	if (fileEntry != nullptr && fileEntry->isValid())
 	{
-		return getCanonicalFilePath(fileId, sourceManager).fileName();
+		return getCanonicalFilePath(fileId, sourceManager);
 	}
 	return getCanonicalFilePath(
 			   utility::decodeFromUtf8(
-				   sourceManager.getPresumedLoc(declaration->getBeginLoc()).getFilename()))
-		.fileName();
+				   sourceManager.getPresumedLoc(declaration->getBeginLoc()).getFilename()));
+}
+
+std::wstring CanonicalFilePathCache::getDeclarationFileName(const clang::Decl* declaration)
+{
+	return getDeclarationFilePath(declaration).fileName();
 }
 
 bool CanonicalFilePathCache::isProjectFile(

--- a/src/lib_cxx/data/parser/cxx/CanonicalFilePathCache.h
+++ b/src/lib_cxx/data/parser/cxx/CanonicalFilePathCache.h
@@ -29,6 +29,7 @@ public:
 	Id getFileSymbolId(const clang::FileEntry* entry);
 	Id getFileSymbolId(const std::wstring& path);
 
+	FilePath getDeclarationFilePath(const clang::Decl* declaration);
 	std::wstring getDeclarationFileName(const clang::Decl* declaration);
 
 	bool isProjectFile(const clang::FileID& fileId, const clang::SourceManager& sourceManager);

--- a/src/lib_cxx/data/parser/cxx/CxxAstVisitorComponentIndexer.cpp
+++ b/src/lib_cxx/data/parser/cxx/CxxAstVisitorComponentIndexer.cpp
@@ -999,7 +999,7 @@ Id CxxAstVisitorComponentIndexer::getOrCreateSymbolId(const clang::NamedDecl* de
 				symbolName.pop();
 				symbolName.push(NameElement(
 					L".:main:." +
-						getAstVisitor()->getCanonicalFilePathCache()->getDeclarationFileName(decl),
+						getAstVisitor()->getCanonicalFilePathCache()->getDeclarationFilePath(decl).wstr(),
 					sig.getPrefix(),
 					sig.getPostfix()));
 			}


### PR DESCRIPTION
regards #233 