### PR TITLE
logic: Less restrictions on FilePath::isValid check

### DIFF
--- a/src/lib/utility/file/FilePath.cpp
+++ b/src/lib/utility/file/FilePath.cpp
@@ -115,17 +115,6 @@ bool FilePath::isAbsolute() const
 
 bool FilePath::isValid() const
 {
-	boost::filesystem::path::iterator end = m_path->end();
-
-	if (!isDirectory())
-	{
-		if (!boost::filesystem::portable_file_name(m_path->filename().generic_string()))
-		{
-			return false;
-		}
-		end--;
-	}
-
 	boost::filesystem::path::iterator it = m_path->begin();
 
 	if (isAbsolute() && m_path->has_root_path())
@@ -139,9 +128,9 @@ bool FilePath::isValid() const
 		}
 	}
 
-	for (; it != end; ++it)
+	for (; it != m_path->end(); ++it)
 	{
-		if (!boost::filesystem::portable_directory_name(it->string()))
+		if (!boost::filesystem::windows_name(it->string()))
 		{
 			return false;
 		}

--- a/src/test/FilePathTestSuite.cpp
+++ b/src/test/FilePathTestSuite.cpp
@@ -215,8 +215,14 @@ TEST_CASE("file path is valid for absolute and relative existing files and direc
 {
 	REQUIRE(FilePath(L"data/FilePathTestSuite/a.cpp").isValid());
 	REQUIRE(FilePath(L"data/FilePathTestSuite/a.cpp").makeAbsolute().isValid());
+	REQUIRE(FilePath(L"data/FilePathTestSuite/with space/s.srctrlprj").isValid());
+	REQUIRE(FilePath(L"data/FilePathTestSuite/with space/s.srctrlprj").makeAbsolute().isValid());
 	REQUIRE(FilePath(L"data/FilePathTestSuite").isValid());
 	REQUIRE(FilePath(L"data/FilePathTestSuite").makeAbsolute().isValid());
+	REQUIRE(FilePath(L"data/FilePathTestSuite/container.app").isValid());
+	REQUIRE(FilePath(L"data/FilePathTestSuite/container.app").makeAbsolute().isValid());
+	REQUIRE(FilePath(L"data/FilePathTestSuite/container.app/b.txt").isValid());
+	REQUIRE(FilePath(L"data/FilePathTestSuite/container.app/b.txt").makeAbsolute().isValid());
 }
 
 TEST_CASE("file path is valid for absolute and relative non-existing files and directories paths")
@@ -225,6 +231,10 @@ TEST_CASE("file path is valid for absolute and relative non-existing files and d
 	REQUIRE(FilePath(L"data/non-existing-file.cpp").makeAbsolute().isValid());
 	REQUIRE(FilePath(L"data/non-existing-dir").isValid());
 	REQUIRE(FilePath(L"data/non-existing-dir").makeAbsolute().isValid());
+	REQUIRE(FilePath(L"data/FilePathTestSuite/container.app/c.txt").isValid());
+	REQUIRE(FilePath(L"data/FilePathTestSuite/container.app/c.txt").makeAbsolute().isValid());
+	REQUIRE(FilePath(L"data/FilePathTestSuite/also space").isValid());
+	REQUIRE(FilePath(L"data/FilePathTestSuite/also space").makeAbsolute().isValid());
 }
 
 TEST_CASE("file path is invalid for absolute and relative paths with invalid characters")
@@ -233,4 +243,6 @@ TEST_CASE("file path is invalid for absolute and relative paths with invalid cha
 	REQUIRE(!FilePath(L"data/non-exis\"ting-file.cpp").makeAbsolute().isValid());
 	REQUIRE(!FilePath(L"data/non-exis|ting-dir").isValid());
 	REQUIRE(!FilePath(L"data/non-exis|ting-dir").makeAbsolute().isValid());
+	REQUIRE(!FilePath(L"data/FilePathTestSuite/container:app").isValid());
+	REQUIRE(!FilePath(L"data/FilePathTestSuite/container:app").makeAbsolute().isValid());
 }


### PR DESCRIPTION
Switch from using `boost::filesystem::portable_name` and `boost::filesystem::portable_directory_name` to using `boost::filesystem::windows_name`, which allows periods and spaces in paths and filenames with extensions longer than three characters (See [boost docs](https://www.boost.org/doc/libs/1_67_0/libs/filesystem/doc/portability_guide.htm)).
fixes #957 