### PR TITLE
Compatibility with MSVC Build Tools (which cannot have Wix targets installed via VS plugin)

### DIFF
--- a/deployment/windows/wixSetup/CustomActions/UninstallRemoveLogFolder/UninstallRemoveLogFolder.csproj
+++ b/deployment/windows/wixSetup/CustomActions/UninstallRemoveLogFolder/UninstallRemoveLogFolder.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>UninstallRemoveLogFolder</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <WixCATargetsPath Condition=" '$(WixCATargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.CA.targets</WixCATargetsPath>
+    <WixCATargetsPath Condition=" '$(WixCATargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.CA.targets')">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.CA.targets</WixCATargetsPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
@@ -66,5 +66,5 @@
     <Content Include="CustomAction.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(WixCATargetsPath)" />
+  <Import Project="$(WixCATargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
 </Project>


### PR DESCRIPTION
I've a vague understanding that this change is exactly what newer Wix templates ship with today for compatibility on Windows build servers without full VS installed.