### PR TITLE
Set C++ standard to C++17 from C++14 (See description)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,8 +72,9 @@ if(UNIX AND NOT APPLE)
 endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_C_STANDARD 99)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_C_STANDARD 11)
 
 
 # Settings ---------------------------------------------------------------------
@@ -366,6 +367,7 @@ if (BUILD_CXX_LANGUAGE_PACKAGE)
 	target_link_libraries(${LIB_CXX_PROJECT_NAME} ${LIB_UTILITY_PROJECT_NAME} ${CLANG_LIBRARIES} ${REQ_LLVM_LIBS})
 
 	if (WIN32)
+		target_compile_definitions(${LIB_CXX_PROJECT_NAME} PRIVATE _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS) # Due to Clang
 		target_link_libraries(${LIB_CXX_PROJECT_NAME} version)
 	endif()
 


### PR DESCRIPTION
Worked for me with CMake 3.17, Boost 1.72.0, Qt 5.15 and Clang 10. Clang was the only issue, in that Windows loudly complained that it wasn't using C++17 native functions, so I had to silence those warnings for the LIB_CXX project. I would have silenced the warnings only within LLVM/Clang includes, but it wasn't clear to me how to do that with CMake. 

Another issue with this -- If our code or underlying code uses DenseMap, Clang has to be compiled with C++17 to work natively with C++17 host applications, or C++14 with C++14. Since the default in CMake for Clang compilation is C++14, this might cause issues or we'll have to document Clang compilation. An alternative would be that the LIB_CXX project compiles with C++14 while the rest of the app compiles with C++17 but that would make code sharing more difficult. The bug was reported here: https://bugs.llvm.org/show_bug.cgi?id=44131 (My preference would be that we ship some kind of script that downloads and compiles dependencies, possibly using CMake.)