### PR TITLE
Updating to copy directory on Windows instead of symlinks on Unix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -817,4 +817,18 @@ if (UNIX)
 		# Linux package
 		include(cmake/linux_package.cmake)
 	endif ()
+elseif(WIN32)
+	# symlinks for data
+	message(STATUS "copy: "
+		"${CMAKE_SOURCE_DIR}/bin/app/data ->"
+		"${CMAKE_BINARY_DIR}/app/data")
+	execute_process(
+		COMMAND "${CMAKE_COMMAND}" "-E" "make_directory" "${CMAKE_BINARY_DIR}/app"
+		COMMAND "${CMAKE_COMMAND}" "-E" "make_directory" "${CMAKE_BINARY_DIR}/test"
+		)
+	execute_process(
+		COMMAND "${CMAKE_COMMAND}" "-E" "copy_directory" "${CMAKE_SOURCE_DIR}/bin/app/data" "${CMAKE_BINARY_DIR}/app/data"
+		COMMAND "${CMAKE_COMMAND}" "-E" "copy_directory" "${CMAKE_SOURCE_DIR}/bin/app/user" "${CMAKE_BINARY_DIR}/app/user"
+		COMMAND "${CMAKE_COMMAND}" "-E" "copy_directory" "${CMAKE_SOURCE_DIR}/bin/test/data" "${CMAKE_BINARY_DIR}/test/data"
+	        )
 endif ()

--- a/src/test/SourceGroupTestSuite.cpp
+++ b/src/test/SourceGroupTestSuite.cpp
@@ -54,14 +54,14 @@ const bool updateExpectedOutput = false;
 
 static FilePath getInputDirectoryPath(const std::wstring& projectName)
 {
-	return FilePath(L"data/SourceGroupTestSuite/" + projectName + L"/input")
+	return FilePath(L"test/data/SourceGroupTestSuite/" + projectName + L"/input")
 		.makeAbsolute()
 		.makeCanonical();
 }
 
 static FilePath getOutputDirectoryPath(const std::wstring& projectName)
 {
-	return FilePath(L"data/SourceGroupTestSuite/" + projectName + L"/expected_output")
+	return FilePath(L"test/data/SourceGroupTestSuite/" + projectName + L"/expected_output")
 		.makeAbsolute()
 		.makeCanonical();
 }


### PR DESCRIPTION
I just noticed the comment isn't quite correct, it was copied/pasted. Also, I'm not sure how this changes things compared to trying to run tests from the current directory of bin/test, which I think the readme mentions, but wasn't clear given this copying. Maybe the symlinks on Unix aren't required and can be dropped? I'll admit I'm a bit confused by how many files we have in the bin/ folders, including a copy of Clang 9 headers it looked like?