### PR TITLE
Add copy to clipboard

### DIFF
--- a/src/lib_gui/qt/graphics/QtGraphicsView.h
+++ b/src/lib_gui/qt/graphics/QtGraphicsView.h
@@ -63,7 +63,9 @@ private slots:
 
 	void openInTab();
 
+	QImage toQImage();
 	void exportGraph();
+	void copyGraph();
 	void copyNodeName();
 
 	void collapseNode();
@@ -127,6 +129,7 @@ private:
 	QAction* m_bookmarkNodeAction;
 
 	QAction* m_exportGraphAction;
+	QAction* m_copyGraphAction;
 
 	QWidget* m_focusIndicator;
 


### PR DESCRIPTION
This PR adds the context option "Save to Clipboard" to the graph viewer. It is bundled together with the "Save as Image" action.
![image](https://user-images.githubusercontent.com/13552216/81108256-b496f300-8f18-11ea-8a28-f330a3cbaeb6.png)


**Motivation**
I often use Sourcetrail alongside a discussion about a design or implementation decision with colleagues.
When such a discussion happens via teleconferencing tool, sending a snapshop of the graph is very useful, but is rather long or cumbersome procedure. Either Save, pick location and name, then open chat, find file, and finally load it; or use a system tool to copy a section of the screen and paste.
With this change, the above simply turns into "Save to Clipboard, open chat, paste"

**Reviewers**
I am not really happy with the internal name `QtGraphicsView::copyGraph` and the menu item `Save to Clipboard` of this feature, but couldn't come up with something better. Do you have suggestions?