### PR TITLE
ui: Fixed crash when changing tabs during animation

### DIFF
--- a/src/lib_gui/qt/graphics/GraphFocusHandler.cpp
+++ b/src/lib_gui/qt/graphics/GraphFocusHandler.cpp
@@ -91,19 +91,21 @@ void GraphFocusHandler::focusTokenId(
 void GraphFocusHandler::refocusNode(
 	const std::list<QtGraphNode*>& newNodes, Id oldActiveTokenId, Id newActiveTokenId)
 {
-	const Id lastFocusId = m_lastFocusId;
-	clear();
-
-	if (lastFocusId && (lastFocusId == newActiveTokenId || oldActiveTokenId == newActiveTokenId))
+	if (m_lastFocusId && (m_lastFocusId == newActiveTokenId || oldActiveTokenId == newActiveTokenId))
 	{
-		QtGraphNode* nodeToFocus = QtGraphNode::findNodeRecursive(newNodes, lastFocusId);
+		QtGraphNode* nodeToFocus = QtGraphNode::findNodeRecursive(newNodes, m_lastFocusId);
 		if (nodeToFocus)
 		{
-			m_focusNode = nodeToFocus;
-			m_lastFocusId = lastFocusId;
-			nodeToFocus->setIsFocused(true);
+			if (m_focusNode != nodeToFocus)
+			{
+				m_focusNode = nodeToFocus;
+				nodeToFocus->setIsFocused(true);
+			}
+			return;
 		}
 	}
+
+	clear();
 }
 
 void GraphFocusHandler::focusNext(Direction direction, bool navigateEdges)
@@ -180,6 +182,11 @@ void GraphFocusHandler::focusNode(QtGraphNode* node)
 
 void GraphFocusHandler::defocusNode(QtGraphNode* node)
 {
+	if (node != m_focusNode)
+	{
+		return;
+	}
+
 	QtGraphNode* parent = node->getParent();
 	while (parent && !parent->isFocusable())
 	{

--- a/src/lib_gui/qt/view/QtGraphView.cpp
+++ b/src/lib_gui/qt/view/QtGraphView.cpp
@@ -937,6 +937,11 @@ void QtGraphView::updateTrailButtons()
 
 void QtGraphView::switchToNewGraphData()
 {
+	// Fixes a crash when switching tabs during an animation where a mouse event defocuses the focused node and moves
+	// the focus to the parent, which is deleted after the animation ends:
+	// https://github.com/CoatiSoftware/Sourcetrail/issues/1021
+	m_focusHandler.refocusNode(m_nodes, 0, 0);
+
 	m_oldGraph = m_graph;
 
 	for (QtGraphNode* node: m_oldNodes)

--- a/src/lib_gui/qt/view/QtGraphView.cpp
+++ b/src/lib_gui/qt/view/QtGraphView.cpp
@@ -937,9 +937,6 @@ void QtGraphView::updateTrailButtons()
 
 void QtGraphView::switchToNewGraphData()
 {
-	// Fixes a crash when switching tabs during an animation where a mouse event defocuses the focused node and moves
-	// the focus to the parent, which is deleted after the animation ends:
-	// https://github.com/CoatiSoftware/Sourcetrail/issues/1021
 	m_focusHandler.refocusNode(m_nodes, 0, 0);
 
 	m_oldGraph = m_graph;


### PR DESCRIPTION
closes #1021 

Fixes a crash when switching tabs during an animation where a mouse event defocuses the focused node and moves
the focus to the parent, which is deleted after the animation ends.