### PR TITLE
fix: duplicating Sourcetrail icon on run

### DIFF
--- a/setup/Linux/data/sourcetrail.desktop
+++ b/setup/Linux/data/sourcetrail.desktop
@@ -10,3 +10,4 @@ Type=Application
 MimeType=application/x-sourcetrail;
 Categories=Development;
 StartupNotify=true
+StartupWMClass=Sourcetrail


### PR DESCRIPTION
fixes #1068