### PR TITLE
Explicitly add u+w permission when copying initial user data

### DIFF
--- a/src/lib_gui/platform_includes/includesLinux.h
+++ b/src/lib_gui/platform_includes/includesLinux.h
@@ -3,6 +3,7 @@
 
 #include <QCoreApplication>
 #include <QDir>
+#include <QDirIterator>
 
 #include "AppPath.h"
 #include "FilePath.h"
@@ -70,6 +71,13 @@ void setupApp(int argc, char* argv[])
 	utility::copyNewFilesFromDirectory(
 		QString::fromStdWString(AppPath::getSharedDataPath().concatenate(L"user/").wstr()),
 		userDataPath);
+
+	// Add u+w permissions because the source files may be marked read-only in some distros
+	QDirIterator it(userDataPath, QDir::Files, QDirIterator::Subdirectories);
+	while (it.hasNext()) {
+		QFile f(it.next());
+		f.setPermissions(f.permissions() | QFile::WriteOwner);
+	}
 }
 
 #endif	  // INCLUDES_DEFAULT_H


### PR DESCRIPTION
This makes the Linux port of Sourcetrail add explicit u+w permissions for files copied to `~/.config/sourcetrail` on first launch. The main purpose of this PR is to make Sourcetrail work well when installed through the Nix package manager. Since files in Nix packages are marked read-only, the files copied into `~/.config/sourcetrail` are also made read-only, preventing users from being able to make changes to the Sourcetrail configuration.