### PR TITLE
Migrate deprecate QT5 usage

### DIFF
--- a/src/lib_gui/qt/element/code/QtCodeArea.cpp
+++ b/src/lib_gui/qt/element/code/QtCodeArea.cpp
@@ -40,7 +40,7 @@ bool MouseWheelOverScrollbarFilter::eventFilter(QObject* obj, QEvent* event)
 	if (event->type() == QEvent::Wheel && scrollbar)
 	{
 		QRect scrollbarArea(scrollbar->pos(), scrollbar->size());
-		QPoint globalMousePos = dynamic_cast<QWheelEvent*>(event)->globalPos();
+		QPoint globalMousePos = dynamic_cast<QWheelEvent*>(event)->globalPosition().toPoint();
 		QPoint localMousePos = scrollbar->mapFromGlobal(globalMousePos);
 
 		// instead of "scrollbar->underMouse()" we need this check implemented here because

--- a/src/lib_gui/utility/utilityApp.cpp
+++ b/src/lib_gui/utility/utilityApp.cpp
@@ -71,9 +71,10 @@ std::pair<int, std::string> utility::executeProcess(
 	}
 
 	QString command = QString::fromStdWString(commandPath);
+	QStringList arguments;
 	for (const std::wstring& commandArgument: commandArguments)
 	{
-		command += QString::fromStdWString(L" " + commandArgument);
+		arguments += QString::fromStdWString(L" " + commandArgument);
 	}
 
 	QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
@@ -85,7 +86,7 @@ std::pair<int, std::string> utility::executeProcess(
 
 	{
 		std::lock_guard<std::mutex> lock(s_runningProcessesMutex);
-		process.start(command);
+		process.start(command, arguments);
 		s_runningProcesses.insert(&process);
 	}
 
@@ -119,9 +120,10 @@ std::string utility::executeProcessUntilNoOutput(
 	}
 
 	QString command = QString::fromStdWString(commandPath);
+	QStringList arguments;
 	for (const std::wstring& commandArgument: commandArguments)
 	{
-		command += QString::fromStdWString(L" " + commandArgument);
+		arguments += QString::fromStdWString(L" " + commandArgument);
 	}
 
 	QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
@@ -133,7 +135,7 @@ std::string utility::executeProcessUntilNoOutput(
 
 	{
 		std::lock_guard<std::mutex> lock(s_runningProcessesMutex);
-		process.start(command);
+		process.start(command, arguments);
 		s_runningProcesses.insert(&process);
 	}
 
@@ -219,9 +221,10 @@ int utility::executeProcessAndGetExitCode(
 	}
 
 	QString command = QString::fromStdWString(commandPath);
+	QStringList arguments;
 	for (const std::wstring& commandArgument: commandArguments)
 	{
-		command += QString::fromStdWString(L" " + commandArgument);
+		arguments += QString::fromStdWString(L" " + commandArgument);
 	}
 
 	QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
@@ -233,7 +236,7 @@ int utility::executeProcessAndGetExitCode(
 
 	{
 		std::lock_guard<std::mutex> lock(s_runningProcessesMutex);
-		process.start(command);
+		process.start(command, arguments);
 		s_runningProcesses.insert(&process);
 	}
 


### PR DESCRIPTION
This PR fixes the use of 2 deprecated interfaces which are unavailable in QT 5.15.1.

1. [QPreocess::start()](https://doc.qt.io/qt-5/qprocess.html#start) has a separate argument for process arguments.
2. [QWheelEvent::globalPos()](https://doc.qt.io/qt-5/qwheelevent-obsolete.html#globalPos) was replaced by `globalPosition()`