### PR TITLE
update deprecated API globalPos to globalPosition

### DIFF
--- a/src/lib_gui/qt/element/code/QtCodeArea.cpp
+++ b/src/lib_gui/qt/element/code/QtCodeArea.cpp
@@ -40,7 +40,7 @@ bool MouseWheelOverScrollbarFilter::eventFilter(QObject* obj, QEvent* event)
 	if (event->type() == QEvent::Wheel && scrollbar)
 	{
 		QRect scrollbarArea(scrollbar->pos(), scrollbar->size());
-		QPoint globalMousePos = dynamic_cast<QWheelEvent*>(event)->globalPos();
+		QPoint globalMousePos = dynamic_cast<QWheelEvent*>(event)->globalPosition().toPoint();
 		QPoint localMousePos = scrollbar->mapFromGlobal(globalMousePos);
 
 		// instead of "scrollbar->underMouse()" we need this check implemented here because


### PR DESCRIPTION
`QWheelEvent::globalPos` is deprecated and replace by `QWheelEvent::globalPosition`:
https://doc.qt.io/qt-5/qwheelevent-obsolete.html#globalPos