### PR TITLE
feat: menu action for graph 'save as image'

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -489,6 +489,7 @@ add_files(
 	utility/messaging/type/graph/MessageGraphNodeHide.h
 	utility/messaging/type/graph/MessageGraphNodeMove.h
 	utility/messaging/type/graph/MessageScrollGraph.h
+	utility/messaging/type/graph/MessageSaveAsImage.h
 
 	utility/messaging/type/history/MessageHistoryToPosition.h
 	utility/messaging/type/history/MessageHistoryRedo.h

--- a/src/lib/utility/messaging/type/MessageSaveAsImage.h
+++ b/src/lib/utility/messaging/type/MessageSaveAsImage.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Message.h"
+
+
+class MessageSaveAsImage: public Message<MessageSaveAsImage>
+{
+public:
+	MessageSaveAsImage(QString path)
+	{
+		this->path = path;
+	}
+
+	static const std::string getStaticType()
+	{
+		return "MessageSaveAsImage";
+	}
+
+	QString path;
+};

--- a/src/lib/utility/messaging/type/graph/MessageSaveAsImage.h
+++ b/src/lib/utility/messaging/type/graph/MessageSaveAsImage.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef MESSAGE_SAVE_AS_IMAGE_H
+#define MESSAGE_SAVE_AS_IMAGE_H
 
 #include "Message.h"
 
@@ -6,10 +7,7 @@
 class MessageSaveAsImage: public Message<MessageSaveAsImage>
 {
 public:
-	MessageSaveAsImage(QString path)
-	{
-		this->path = path;
-	}
+	MessageSaveAsImage(QString path) : path(path) {}
 
 	static const std::string getStaticType()
 	{
@@ -18,3 +16,5 @@ public:
 
 	QString path;
 };
+
+#endif /* MESSAGE_SAVE_AS_IMAGE_H */

--- a/src/lib_gui/qt/graphics/QtGraphicsView.cpp
+++ b/src/lib_gui/qt/graphics/QtGraphicsView.cpp
@@ -183,6 +183,7 @@ void QtGraphicsView::setSceneRect(const QRectF& rect)
 {
 	QGraphicsView::setSceneRect(rect);
 	scene()->setSceneRect(rect);
+	imageCached = toQImage();
 }
 
 QtGraphNode* QtGraphicsView::getNodeAtCursorPosition() const
@@ -602,6 +603,7 @@ void QtGraphicsView::focusInEvent(QFocusEvent* event)
 	emit focusIn();
 
 	MessageFocusView(MessageFocusView::ViewType::GRAPH).dispatch();
+	lastViewFocused = this;
 }
 
 void QtGraphicsView::focusOutEvent(QFocusEvent* event)
@@ -723,7 +725,6 @@ void QtGraphicsView::exportGraph()
 			FilePath(),
 			QStringLiteral("PNG (*.png);;JPEG (*.JPEG);;BMP Files (*.bmp);;SVG (*.svg)"))
 			.toStdWString());
-
 
 	if (filePath.extension() == L".svg")
 	{
@@ -851,4 +852,14 @@ void QtGraphicsView::updateTransform()
 {
 	float zoomFactor = m_appZoomFactor * m_zoomFactor;
 	setTransform(QTransform(zoomFactor, 0, 0, zoomFactor, 0, 0));
+}
+
+QtGraphicsView* QtGraphicsView::lastViewFocused;
+
+void QtGraphicsView::handleMessage(MessageSaveAsImage* message)
+{
+	if ( (lastViewFocused == this) && !imageCached.isNull() )
+	{
+		imageCached.save(message->path);
+	}
 }

--- a/src/lib_gui/qt/graphics/QtGraphicsView.cpp
+++ b/src/lib_gui/qt/graphics/QtGraphicsView.cpp
@@ -166,6 +166,8 @@ QtGraphicsView::QtGraphicsView(GraphFocusHandler* focusHandler, QWidget* parent)
 	m_legendButton->setObjectName(QStringLiteral("legend_button"));
 	m_legendButton->setToolTip(QStringLiteral("show legend"));
 	connect(m_legendButton, &QPushButton::clicked, this, &QtGraphicsView::legendClicked);
+
+	m_tabId = TabId::currentTab();
 }
 
 float QtGraphicsView::getZoomFactor() const
@@ -183,7 +185,8 @@ void QtGraphicsView::setSceneRect(const QRectF& rect)
 {
 	QGraphicsView::setSceneRect(rect);
 	scene()->setSceneRect(rect);
-	imageCached = toQImage();
+	m_imageCached = toQImage();
+	m_tabId = TabId::currentTab();
 }
 
 QtGraphNode* QtGraphicsView::getNodeAtCursorPosition() const
@@ -603,7 +606,6 @@ void QtGraphicsView::focusInEvent(QFocusEvent* event)
 	emit focusIn();
 
 	MessageFocusView(MessageFocusView::ViewType::GRAPH).dispatch();
-	lastViewFocused = this;
 }
 
 void QtGraphicsView::focusOutEvent(QFocusEvent* event)
@@ -854,12 +856,10 @@ void QtGraphicsView::updateTransform()
 	setTransform(QTransform(zoomFactor, 0, 0, zoomFactor, 0, 0));
 }
 
-QtGraphicsView* QtGraphicsView::lastViewFocused;
-
 void QtGraphicsView::handleMessage(MessageSaveAsImage* message)
 {
-	if ( (lastViewFocused == this) && !imageCached.isNull() )
+	if ( (message->getSchedulerId() == getSchedulerId()) && !m_imageCached.isNull() )
 	{
-		imageCached.save(message->path);
+		m_imageCached.save(message->path);
 	}
 }

--- a/src/lib_gui/qt/graphics/QtGraphicsView.h
+++ b/src/lib_gui/qt/graphics/QtGraphicsView.h
@@ -6,6 +6,9 @@
 #include <QGraphicsView>
 
 #include "types.h"
+#include "MessageListener.h"
+#include "MessageSaveAsImage.h"
+
 
 class GraphFocusHandler;
 class QPushButton;
@@ -14,7 +17,7 @@ class QtGraphEdge;
 class QtGraphNode;
 class QtSelfRefreshIconButton;
 
-class QtGraphicsView: public QGraphicsView
+class QtGraphicsView: public QGraphicsView, public MessageListener<MessageSaveAsImage>
 {
 	Q_OBJECT
 
@@ -90,6 +93,8 @@ private:
 	void setZoomFactor(float zoomFactor);
 	void updateTransform();
 
+	void handleMessage(MessageSaveAsImage* message) override;
+
 	GraphFocusHandler* m_focusHandler;
 
 	QPoint m_last;
@@ -141,6 +146,9 @@ private:
 
 	float m_zoomInButtonSpeed;
 	float m_zoomOutButtonSpeed;
+
+	QImage imageCached;
+	static QtGraphicsView* lastViewFocused;
 };
 
 #endif	  // QT_GRAPHICS_VIEW_H

--- a/src/lib_gui/qt/graphics/QtGraphicsView.h
+++ b/src/lib_gui/qt/graphics/QtGraphicsView.h
@@ -36,6 +36,11 @@ public:
 
 	void updateZoom(float delta);
 
+	Id getSchedulerId() const override
+	{
+		return m_tabId;
+	}
+
 protected:
 	void resizeEvent(QResizeEvent* event);
 
@@ -147,8 +152,8 @@ private:
 	float m_zoomInButtonSpeed;
 	float m_zoomOutButtonSpeed;
 
-	QImage imageCached;
-	static QtGraphicsView* lastViewFocused;
+	QImage m_imageCached;
+	Id m_tabId;
 };
 
 #endif	  // QT_GRAPHICS_VIEW_H

--- a/src/lib_gui/qt/window/QtMainWindow.cpp
+++ b/src/lib_gui/qt/window/QtMainWindow.cpp
@@ -38,6 +38,7 @@
 #include "MessageTabSelect.h"
 #include "MessageWindowClosed.h"
 #include "MessageZoom.h"
+#include "MessageSaveAsImage.h"
 #include "QtAbout.h"
 #include "QtContextMenu.h"
 #include "QtFileDialog.h"
@@ -710,6 +711,17 @@ void QtMainWindow::forceRefresh()
 	MessageRefresh().refreshAll().dispatch();
 }
 
+void QtMainWindow::saveAsImage()
+{
+	QString filePath = QtFileDialog::showSaveFileDialog(this, tr("Save as Image"), FilePath(), 
+		"PNG (*.png);;JPEG (*.JPEG);;BMP Files (*.bmp)");
+	if (filePath.isNull())
+	{
+		return;
+	}
+	MessageSaveAsImage(filePath).dispatch();
+}
+
 void QtMainWindow::undo()
 {
 	MessageHistoryUndo().dispatch();
@@ -924,6 +936,8 @@ void QtMainWindow::setupEditMenu()
 		this,
 		&QtMainWindow::openSettings,
 		QKeySequence(Qt::CTRL + Qt::Key_Comma));
+
+	menu->addAction(tr("&Save as Image"), this, &QtMainWindow::saveAsImage, QKeySequence(Qt::SHIFT + Qt::CTRL + Qt::Key_S));
 }
 
 void QtMainWindow::setupViewMenu()

--- a/src/lib_gui/qt/window/QtMainWindow.cpp
+++ b/src/lib_gui/qt/window/QtMainWindow.cpp
@@ -719,7 +719,9 @@ void QtMainWindow::saveAsImage()
 	{
 		return;
 	}
-	MessageSaveAsImage(filePath).dispatch();
+	MessageSaveAsImage m(filePath);
+	m.setSchedulerId(TabId::currentTab());
+	m.dispatch();
 }
 
 void QtMainWindow::undo()

--- a/src/lib_gui/qt/window/QtMainWindow.h
+++ b/src/lib_gui/qt/window/QtMainWindow.h
@@ -150,6 +150,7 @@ public slots:
 	void updateRecentProjectsMenu();
 
 	void toggleView(View* view, bool fromMenu);
+	void saveAsImage();
 
 private slots:
 	void toggleShowDockWidgetTitleBars();


### PR DESCRIPTION
Resolves #426 

**How to test**:
1. Launch Sourcetrail and open any project
2. Click on graph *(see first issue)*
3. Select "Edit" -> "Save as Image" and choose a path to save
Expected result: graph image is saved at chosen path
4. Open another graph in second tab (this project or another one)
5. Click on graph on newly opened tab *(see first issue)*
6. Select "Edit" -> "Save as Image" and choose a path to save
Expected result: graph from second tab is saved at chosen path

**Issues:**
1. Graph should be clicked at least once to be marked as focused. Last focused graph is remembered to trigger saving only for needed one, not for all opened graphs.
2. `exportGraph()` direct reuse failed for me, so I copy-pasted dialog creation to QtMainWindow.cpp. The issue was in GLib assertions like this:
```
(Sourcetrail:23434): GLib-GObject-CRITICAL **: 11:11:44.894: g_value_take_string: assertion 'G_VALUE_HOLDS_STRING (value)' failed
(Sourcetrail:23434): GLib-GObject-WARNING **: 11:11:44.894: ../../../gobject/gtype.c:4268: type id '0' is invalid
(Sourcetrail:23434): GLib-GObject-WARNING **: 11:11:44.894: can't peek value table for type '<invalid>' which is not currently referenced
(Sourcetrail:23434): GLib-GObject-WARNING **: 11:11:44.894: ../../../gobject/gvalue.c:185: cannot initialize GValue with type '(null)', this type has no GTypeValueTable implementation
(Sourcetrail:23434): GLib-GObject-CRITICAL **: 11:11:44.894: g_value_type_compatible: assertion 'src_type' failed
(Sourcetrail:23434): GLib-GObject-CRITICAL **: 11:11:44.894: g_value_copy: assertion 'g_value_type_compatible (G_VALUE_TYPE (src_value), G_VALUE_TYPE (dest_value))' failed
```
I think that this can be caused by `nullptr` passing as a parent to QFileDialog. Anyway GLib floods log with errors and `filePath` is empty in result.

**Notes:**
1. Graph image creation at message handling moment causes a segfault or empty image. Seems like that `QtGraphicsView` object is not in a proper state at that moment. So I added image caching to avoid this.
2. SVG format excluded for now because of second above-mentioned issue. Just to not copy-paste this logic again to QtMainWindow.cpp.

**Questions:**
1. I used last filepicker location for saving dialog initializing directory because this is most probably be project directory. Maybe change it to user home directory? Maybe add a placeholder image name like "${project_name}_${view_name}.png"?
2. I bound Ctrl+Shift+S hotkey to this action. Is this combination fine and is hotkey needed at all?