### PR TITLE
Migrate QProcess::start() to QStringList

### DIFF
--- a/src/lib/data/indexer/TaskBuildIndex.cpp
+++ b/src/lib/data/indexer/TaskBuildIndex.cpp
@@ -188,16 +188,16 @@ void TaskBuildIndex::runIndexerProcess(int processId, const std::wstring& logFil
 		return;
 	}
 
-	const std::wstring commandPath = L"\"" + indexerProcessPath.wstr() + L"\"";
+	const std::wstring commandPath = indexerProcessPath.wstr();
 	std::vector<std::wstring> commandArguments;
 	commandArguments.push_back(std::to_wstring(processId));
 	commandArguments.push_back(utility::decodeFromUtf8(m_appUUID));
-	commandArguments.push_back(L"\"" + AppPath::getSharedDataPath().getAbsolute().wstr() + L"\"");
-	commandArguments.push_back(L"\"" + UserPaths::getUserDataPath().getAbsolute().wstr() + L"\"");
+	commandArguments.push_back(AppPath::getSharedDataPath().getAbsolute().wstr());
+	commandArguments.push_back(UserPaths::getUserDataPath().getAbsolute().wstr());
 
 	if (!logFilePath.empty())
 	{
-		commandArguments.push_back(L"\"" + logFilePath + L"\"");
+		commandArguments.push_back(logFilePath);
 	}
 
 	int result = 1;

--- a/src/lib_gui/utility/utilityApp.cpp
+++ b/src/lib_gui/utility/utilityApp.cpp
@@ -48,6 +48,16 @@ void logProcessStreams(QProcess& process, std::wstring& outputBuffer, std::wstri
 		errorBuffer = errorLines.back();
 	}
 }
+
+QStringList toQStringList(const std::vector<std::wstring>& strings)
+{
+	QStringList result;
+	for (const std::wstring& next: strings)
+	{
+		result += QString::fromStdWString(next);
+	}
+	return result;
+}
 }	 // namespace
 
 namespace utility
@@ -71,10 +81,7 @@ std::pair<int, std::string> utility::executeProcess(
 	}
 
 	QString command = QString::fromStdWString(commandPath);
-	for (const std::wstring& commandArgument: commandArguments)
-	{
-		command += QString::fromStdWString(L" " + commandArgument);
-	}
+	QStringList arguments = toQStringList(commandArguments);
 
 	QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
 	QStringList envlist = env.toStringList();
@@ -85,7 +92,7 @@ std::pair<int, std::string> utility::executeProcess(
 
 	{
 		std::lock_guard<std::mutex> lock(s_runningProcessesMutex);
-		process.start(command);
+		process.start(command, arguments);
 		s_runningProcesses.insert(&process);
 	}
 
@@ -119,10 +126,7 @@ std::string utility::executeProcessUntilNoOutput(
 	}
 
 	QString command = QString::fromStdWString(commandPath);
-	for (const std::wstring& commandArgument: commandArguments)
-	{
-		command += QString::fromStdWString(L" " + commandArgument);
-	}
+	QStringList arguments = toQStringList(commandArguments);
 
 	QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
 	QStringList envlist = env.toStringList();
@@ -133,7 +137,7 @@ std::string utility::executeProcessUntilNoOutput(
 
 	{
 		std::lock_guard<std::mutex> lock(s_runningProcessesMutex);
-		process.start(command);
+		process.start(command, arguments);
 		s_runningProcesses.insert(&process);
 	}
 
@@ -219,10 +223,7 @@ int utility::executeProcessAndGetExitCode(
 	}
 
 	QString command = QString::fromStdWString(commandPath);
-	for (const std::wstring& commandArgument: commandArguments)
-	{
-		command += QString::fromStdWString(L" " + commandArgument);
-	}
+	QStringList arguments = toQStringList(commandArguments);
 
 	QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
 	QStringList envlist = env.toStringList();
@@ -233,7 +234,7 @@ int utility::executeProcessAndGetExitCode(
 
 	{
 		std::lock_guard<std::mutex> lock(s_runningProcessesMutex);
-		process.start(command);
+		process.start(command, arguments);
 		s_runningProcesses.insert(&process);
 	}
 


### PR DESCRIPTION
The non-QStringList variant of [`QProcess::start()`](https://doc.qt.io/qt-5.12/qprocess.html#start) was removed in [Qt 5.15](https://doc.qt.io/qt-5.15/qprocess.html#start)
This PR migrates the process related utilities to the `QStringList` overload, which is supported by both Qt 5.12 and 5.15.

As a bonus, the adapted method handles escaping of the arguments, which simplifies code in some locations.

This PR is essentially a salvaged part of #1082

**Reviewers:** I am using this locally with the C++ indexer on Linux. Can you please test the behaviour with the remaining indexers and on other systems?