### PR TITLE
Add compatibility layer for Qt versions

### DIFF
--- a/src/lib_gui/CMakeLists.txt
+++ b/src/lib_gui/CMakeLists.txt
@@ -186,6 +186,8 @@ add_files(
 	qt/project_wizard/QtProjectWizardWindow.cpp
 	qt/project_wizard/QtProjectWizardWindow.h
 
+	qt/utility/compatibilityQt.cpp
+	qt/utility/compatibilityQt.h
 	qt/utility/QtContextMenu.cpp
 	qt/utility/QtContextMenu.h
 	qt/utility/QtDeviceScaledPixmap.cpp

--- a/src/lib_gui/qt/element/code/QtCodeArea.cpp
+++ b/src/lib_gui/qt/element/code/QtCodeArea.cpp
@@ -31,6 +31,7 @@
 #include "utility.h"
 #include "utilityApp.h"
 #include "utilityString.h"
+#include "compatibilityQt.h"
 
 MouseWheelOverScrollbarFilter::MouseWheelOverScrollbarFilter() {}
 
@@ -40,7 +41,7 @@ bool MouseWheelOverScrollbarFilter::eventFilter(QObject* obj, QEvent* event)
 	if (event->type() == QEvent::Wheel && scrollbar)
 	{
 		QRect scrollbarArea(scrollbar->pos(), scrollbar->size());
-		QPoint globalMousePos = dynamic_cast<QWheelEvent*>(event)->globalPos();
+		QPoint globalMousePos = utility::compatibility::QWheelEvent_globalPos(*dynamic_cast<QWheelEvent*>(event));
 		QPoint localMousePos = scrollbar->mapFromGlobal(globalMousePos);
 
 		// instead of "scrollbar->underMouse()" we need this check implemented here because

--- a/src/lib_gui/qt/utility/compatibilityQt.cpp
+++ b/src/lib_gui/qt/utility/compatibilityQt.cpp
@@ -1,0 +1,18 @@
+#include "compatibilityQt.h"
+
+#include <QtGlobal>
+
+namespace utility
+{
+namespace compatibility
+{
+QPoint QWheelEvent_globalPos(const QWheelEvent& event)
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+	return event.globalPosition().toPoint();
+#else
+	return event.globalPos();
+#endif
+}
+}	 // namespace compatibility
+}	 // namespace utility

--- a/src/lib_gui/qt/utility/compatibilityQt.h
+++ b/src/lib_gui/qt/utility/compatibilityQt.h
@@ -1,0 +1,17 @@
+#ifndef COMPATIBILITY_QT_H
+#define COMPATIBILITY_QT_H
+
+#include <QWheelEvent>
+
+namespace utility
+{
+namespace compatibility
+{
+// Extracts the global position from a QWheelEvent.
+// This compatibility wrapper bridges Qt 5.12 and Qt 5.14
+QPoint QWheelEvent_globalPos(const QWheelEvent& event);
+
+}	 // namespace compatibility
+}	 // namespace utility
+
+#endif	  // COMPATIBILITY_QT_H


### PR DESCRIPTION
This PR adds a compatability layer to bridge compatability between Qt version.
I added this as a separate file to simplify future migrations in case the minimum version changes.

Currently this only contains a compatability wrapper for `QWheelEvent::globalPos()`, which was deprecated in Qt 5.14.

This allows to compile Sourcetrail with Qt versions 5.12 - 5.15.

Longer discussion against the full migration: #975
