### PR TITLE
ui: move "Save Graph as Image..." up in "Edit" menu to keep "Preferences..." at the bottom

### DIFF
--- a/src/lib_gui/qt/window/QtMainWindow.cpp
+++ b/src/lib_gui/qt/window/QtMainWindow.cpp
@@ -33,12 +33,12 @@
 #include "MessageRefresh.h"
 #include "MessageRefreshUI.h"
 #include "MessageResetZoom.h"
+#include "MessageSaveAsImage.h"
 #include "MessageTabClose.h"
 #include "MessageTabOpen.h"
 #include "MessageTabSelect.h"
 #include "MessageWindowClosed.h"
 #include "MessageZoom.h"
-#include "MessageSaveAsImage.h"
 #include "QtAbout.h"
 #include "QtContextMenu.h"
 #include "QtFileDialog.h"
@@ -713,8 +713,8 @@ void QtMainWindow::forceRefresh()
 
 void QtMainWindow::saveAsImage()
 {
-	QString filePath = QtFileDialog::showSaveFileDialog(this, tr("Save as Image"), FilePath(), 
-		"PNG (*.png);;JPEG (*.JPEG);;BMP Files (*.bmp)");
+	QString filePath = QtFileDialog::showSaveFileDialog(
+		this, tr("Save as Image"), FilePath(), "PNG (*.png);;JPEG (*.JPEG);;BMP Files (*.bmp)");
 	if (filePath.isNull())
 	{
 		return;
@@ -934,12 +934,18 @@ void QtMainWindow::setupEditMenu()
 	menu->addSeparator();
 
 	menu->addAction(
+		tr("&Save Graph as Image..."),
+		this,
+		&QtMainWindow::saveAsImage,
+		QKeySequence(Qt::SHIFT + Qt::CTRL + Qt::Key_S));
+
+	menu->addSeparator();
+
+	menu->addAction(
 		tr("Preferences..."),
 		this,
 		&QtMainWindow::openSettings,
 		QKeySequence(Qt::CTRL + Qt::Key_Comma));
-
-	menu->addAction(tr("&Save as Image"), this, &QtMainWindow::saveAsImage, QKeySequence(Qt::SHIFT + Qt::CTRL + Qt::Key_S));
 }
 
 void QtMainWindow::setupViewMenu()
@@ -1150,7 +1156,9 @@ void QtMainWindow::setShowDockWidgetTitleBars(bool showTitleBars)
 	{
 		if (showTitleBars)
 		{
-			dock.widget->setFeatures(QDockWidget::DockWidgetClosable | QDockWidget::DockWidgetMovable | QDockWidget::DockWidgetFloatable);
+			dock.widget->setFeatures(
+				QDockWidget::DockWidgetClosable | QDockWidget::DockWidgetMovable |
+				QDockWidget::DockWidgetFloatable);
 			dock.widget->setTitleBarWidget(nullptr);
 		}
 		else


### PR DESCRIPTION
This is done because users may already be used to "preferences" being the bottom-most button and may accidentally click "Save Graph as Image..." when they actually want to open the preferences screen.