### PR TITLE
src: revert migration of QProcess::start() to QStringList

### DIFF
--- a/src/lib/data/indexer/TaskBuildIndex.cpp
+++ b/src/lib/data/indexer/TaskBuildIndex.cpp
@@ -188,16 +188,16 @@ void TaskBuildIndex::runIndexerProcess(int processId, const std::wstring& logFil
 		return;
 	}
 
-	const std::wstring commandPath = indexerProcessPath.wstr();
+	const std::wstring commandPath = L"\"" + indexerProcessPath.wstr() + L"\"";
 	std::vector<std::wstring> commandArguments;
 	commandArguments.push_back(std::to_wstring(processId));
 	commandArguments.push_back(utility::decodeFromUtf8(m_appUUID));
-	commandArguments.push_back(AppPath::getSharedDataPath().getAbsolute().wstr());
-	commandArguments.push_back(UserPaths::getUserDataPath().getAbsolute().wstr());
+	commandArguments.push_back(L"\"" + AppPath::getSharedDataPath().getAbsolute().wstr() + L"\"");
+	commandArguments.push_back(L"\"" + UserPaths::getUserDataPath().getAbsolute().wstr() + L"\"");
 
 	if (!logFilePath.empty())
 	{
-		commandArguments.push_back(logFilePath);
+		commandArguments.push_back(L"\"" + logFilePath + L"\"");
 	}
 
 	int result = 1;

--- a/src/lib_gui/utility/path_detector/maven_executable/MavenPathDetectorWindows.cpp
+++ b/src/lib_gui/utility/path_detector/maven_executable/MavenPathDetectorWindows.cpp
@@ -7,9 +7,7 @@ MavenPathDetectorWindows::MavenPathDetectorWindows(): PathDetector("Maven for Wi
 
 std::vector<FilePath> MavenPathDetectorWindows::doGetPaths() const
 {
-	FilePath mavenPath(
-		utility::executeProcess(L"cmd", std::vector<std::wstring> {L"\"/c where mvn.cmd && exit\""})
-			.second);
+	FilePath mavenPath(utility::executeProcess(L"cmd", std::vector<std::wstring>{L"/c where mvn.cmd && exit"}).second);
 
 	std::vector<FilePath> paths;
 	if (mavenPath.exists())

--- a/src/lib_gui/utility/utilityApp.cpp
+++ b/src/lib_gui/utility/utilityApp.cpp
@@ -48,16 +48,6 @@ void logProcessStreams(QProcess& process, std::wstring& outputBuffer, std::wstri
 		errorBuffer = errorLines.back();
 	}
 }
-
-QStringList toQStringList(const std::vector<std::wstring>& strings)
-{
-	QStringList result;
-	for (const std::wstring& next: strings)
-	{
-		result += QString::fromStdWString(next);
-	}
-	return result;
-}
 }	 // namespace
 
 namespace utility
@@ -81,7 +71,10 @@ std::pair<int, std::string> utility::executeProcess(
 	}
 
 	QString command = QString::fromStdWString(commandPath);
-	QStringList arguments = toQStringList(commandArguments);
+	for (const std::wstring& commandArgument: commandArguments)
+	{
+		command += QString::fromStdWString(L" " + commandArgument);
+	}
 
 	QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
 	QStringList envlist = env.toStringList();
@@ -92,7 +85,7 @@ std::pair<int, std::string> utility::executeProcess(
 
 	{
 		std::lock_guard<std::mutex> lock(s_runningProcessesMutex);
-		process.start(command, arguments);
+		process.start(command);
 		s_runningProcesses.insert(&process);
 	}
 
@@ -126,7 +119,10 @@ std::string utility::executeProcessUntilNoOutput(
 	}
 
 	QString command = QString::fromStdWString(commandPath);
-	QStringList arguments = toQStringList(commandArguments);
+	for (const std::wstring& commandArgument: commandArguments)
+	{
+		command += QString::fromStdWString(L" " + commandArgument);
+	}
 
 	QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
 	QStringList envlist = env.toStringList();
@@ -137,7 +133,7 @@ std::string utility::executeProcessUntilNoOutput(
 
 	{
 		std::lock_guard<std::mutex> lock(s_runningProcessesMutex);
-		process.start(command, arguments);
+		process.start(command);
 		s_runningProcesses.insert(&process);
 	}
 
@@ -223,7 +219,10 @@ int utility::executeProcessAndGetExitCode(
 	}
 
 	QString command = QString::fromStdWString(commandPath);
-	QStringList arguments = toQStringList(commandArguments);
+	for (const std::wstring& commandArgument: commandArguments)
+	{
+		command += QString::fromStdWString(L" " + commandArgument);
+	}
 
 	QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
 	QStringList envlist = env.toStringList();
@@ -234,7 +233,7 @@ int utility::executeProcessAndGetExitCode(
 
 	{
 		std::lock_guard<std::mutex> lock(s_runningProcessesMutex);
-		process.start(command, arguments);
+		process.start(command);
 		s_runningProcesses.insert(&process);
 	}
 


### PR DESCRIPTION
The reverted change has caused the Linux release to fail at indexing any Python project