### PR TITLE
fix: java path detection failures on linux

### DIFF
--- a/src/lib_gui/utility/path_detector/java_runtime/JavaPathDetectorLinux.cpp
+++ b/src/lib_gui/utility/path_detector/java_runtime/JavaPathDetectorLinux.cpp
@@ -72,7 +72,7 @@ FilePath JavaPathDetectorLinux::getJavaInPath() const
 
 FilePath JavaPathDetectorLinux::readLink(const FilePath& path) const
 {
-	FilePath javaPath(utility::executeProcess(L"readlink", std::vector<std::wstring>{L"-f " + path.wstr()}).second);
+	FilePath javaPath(utility::executeProcess(L"readlink", std::vector<std::wstring>{L"-f", path.wstr()}).second);
 	if (!javaPath.empty())
 	{
 		return javaPath;


### PR DESCRIPTION
readlink was being invoked as `"readlink" "-f path/to/java"`. It should've been `"readlink" "-f" "path/to/java"` instead.

This can verified by running the tests and looking at the output of the following command:

    $ sudo execsnoop -q | grep readlink
    readlink         2060   1925     0 "/nix/store/0y7rv26ffa359wvqd3js94cn73z882fg-coreutils-8.32/bin/readlink" "-f /nix/store/d5mpdil4c8z466f9zyxywxg5lm2zk3ls-openjdk-8u272-b10-jre/bin/java"
    readlink         2081   1925     0 "/nix/store/0y7rv26ffa359wvqd3js94cn73z882fg-coreutils-8.32/bin/readlink" "-f /nix/store/xr5xm2bmfhd02v8h9ghzmhbcdc49ms55-openjdk-8u272-b10/lib/openjdk/jre/bin/java"