### PR TITLE
src: fix multi-level inheritance edges when there are diamonds

### DIFF
--- a/src/lib/data/HierarchyCache.h
+++ b/src/lib/data/HierarchyCache.h
@@ -33,10 +33,29 @@ public:
 	bool nodeIsVisible(Id nodeId) const;
 	bool nodeIsImplicit(Id nodeId) const;
 
-	std::vector<std::tuple<Id, Id, std::vector<Id>>> getInheritanceEdgesForNodeId(
-		Id nodeId, const std::set<Id>& nodeIds) const;
+	std::vector<std::tuple</*source*/ Id, /*target*/ Id, std::vector</*edge*/ Id>>>
+		getInheritanceEdgesForNodeId(Id sourceId, const std::set<Id>& targetIds) const;
 
 private:
+	/**
+	 * Determine nodes and edges from which a specific node can be reached in a reversed graph.
+	 *
+	 * A reversed graph can be produced by HierarchyNode::getReverseReachableInheritanceSubgraph().
+	 *
+	 * @param[in]  nodeId        ID of the target node.
+	 * @param[in]  reverseGraph  The reversed graph.
+	 * @param[out] nodes         The nodes from which the node @p nodeId can be reached.
+	 * @param[out] edges         The edges from which the node @p nodeId can be reached.
+	 *
+	 * @pre The arguments for @p nodes and @p edges must be provided empty.
+	 */
+	static void getReverseReachable(
+		Id nodeId,
+		const std::map</*target*/ Id, std::vector<std::pair</*source*/ Id, /*edge*/ Id>>>&
+			reverseGraph,
+		std::set<Id>& nodes,
+		std::vector<Id>& edges);
+
 	class HierarchyNode
 	{
 	public:
@@ -67,13 +86,23 @@ private:
 		bool isImplicit() const;
 		void setIsImplicit(bool isImplicit);
 
-		void addInheritanceEdgesRecursive(
-			Id startId,
-			const std::set<Id>& inheritanceEdgeIds,
-			const std::set<Id>& nodeIds,
-			std::vector<std::tuple<Id, Id, std::vector<Id>>>* inheritanceEdges);
+		/**
+		 * Determine the reversed subgraph of all nodes and edges that are reachable from this node.
+		 *
+		 * The subgraph is represented by a map that maps a node ID *t* to a set of pairs where each
+		 * pair consists of a node ID *s* and and edge ID *e* such that *e* refers to an edge from
+		 * *s* to *t*. Note that the mapping is reversed compared to the edges.
+		 */
+		std::map</*target*/ Id, std::vector<std::pair</*source*/ Id, /*edge*/ Id>>>
+			getReverseReachableInheritanceSubgraph() const;
 
 	private:
+		/**
+		 * Helper for getReverseReachableInheritanceSubgraph().
+		 */
+		void getReverseReachableInheritanceSubgraphHelper(
+			std::map</*target*/ Id, std::vector<std::pair</*source*/ Id, /*edge*/ Id>>>&) const;
+
 		const Id m_nodeId;
 		Id m_edgeId;
 


### PR DESCRIPTION
The old implementation produces several multi-inheritance edges between two classes if there are multiple inheritance paths between them due to multiple inheritance diamonds. The new implementation produces only one edge in such a case.

Also, the old implementation has performance issues when there is a huge number of inheritance paths starting at the focused class. With a pathological multiple inheritance class structure, the number of paths can be exponential in the number of involved classes. The new implementation solves this issue by considering subgraphs instead of paths.

---

I have a project (which, unfortunately, I cannot share as is) where the previous implementation seemingly got stuck within `addInheritanceEdgesRecursive` when looking up a specific symbol. With this change, the function returns almost instantly for the same lookup.

The following is a small problematic example, which does not show the performance problem due to its small size. However, when focusing on `X::foo`, the old implementation produces 4 different multi-level inheritance edges from `X` to `B1` while the new implementation produces only one multi-level inheritance edge, which is basically the union of the edges of the old implementation:
```c++
struct B1 {
	virtual void foo() = 0;
};
struct C1 : B1 {};
struct D1 : B1 {};
struct B2 : C1, D1 {};
struct C2 : B2 {};
struct D2 : B2 {};
struct B3 : C2, D2 {};

struct X : B3 {
	void foo() override {};
};

int main () {
	X x;
	x.foo();
	return 0;
}
```