### PR TITLE
src: switch from Qt to boost implementation of executeProcess

### DIFF
--- a/bin/test/data/SourceGroupTestSuite/custom_command/expected_output/output_unix.txt
+++ b/bin/test/data/SourceGroupTestSuite/custom_command/expected_output/output_unix.txt
@@ -1,6 +1,12 @@
-SourceFilePath: "src/a.txt"
+IndexerCommandCustom
+	SourceFilePath: "src/a.txt"
 	Custom Command: "echo "Hello World""
-SourceFilePath: "src/b.txt"
+	Arguments:
+IndexerCommandCustom
+	SourceFilePath: "src/b.txt"
 	Custom Command: "echo "Hello World""
-SourceFilePath: "src/included/a.txt"
+	Arguments:
+IndexerCommandCustom
+	SourceFilePath: "src/included/a.txt"
 	Custom Command: "echo "Hello World""
+	Arguments:

--- a/bin/test/data/SourceGroupTestSuite/custom_command/expected_output/output_windows.txt
+++ b/bin/test/data/SourceGroupTestSuite/custom_command/expected_output/output_windows.txt
@@ -1,6 +1,12 @@
-SourceFilePath: "src/a.txt"
+IndexerCommandCustom
+	SourceFilePath: "src/a.txt"
 	Custom Command: "echo "Hello World""
-SourceFilePath: "src/b.txt"
+	Arguments:
+IndexerCommandCustom
+	SourceFilePath: "src/b.txt"
 	Custom Command: "echo "Hello World""
-SourceFilePath: "src/included/a.txt"
+	Arguments:
+IndexerCommandCustom
+	SourceFilePath: "src/included/a.txt"
 	Custom Command: "echo "Hello World""
+	Arguments:

--- a/script/download_python_indexer.sh
+++ b/script/download_python_indexer.sh
@@ -94,6 +94,7 @@ fi
 echo -e $INFO "clearing $TARGET_PATH"
 rm -rf $TARGET_PATH
 mkdir -p $TARGET_PATH
+echo -e $INFO "copying downloaded data to $TARGET_PATH"
 cp -r $TEMP_PATH/$PACKAGE_NAME/* $TARGET_PATH
 
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -93,6 +93,11 @@ void addLanguagePackages()
 
 int main(int argc, char* argv[])
 {
+	// auto p = utility::executeProcessBoost(utility::searchPath(L"mvn") + L" --version", FilePath("/Users/ebsi/Documents/boost_1_67_0"), 3000);
+	// std::wcout << p.first << " " << p.second << std::endl;
+	// return 0;
+
+
 	QCoreApplication::addLibraryPath(QStringLiteral("."));
 
 #pragma warning(push)

--- a/src/lib/app/paths/ResourcePaths.cpp
+++ b/src/lib/app/paths/ResourcePaths.cpp
@@ -1,6 +1,7 @@
 #include "ResourcePaths.h"
 
 #include "AppPath.h"
+#include "utilityApp.h"
 
 FilePath ResourcePaths::getColorSchemesPath()
 {
@@ -37,7 +38,7 @@ FilePath ResourcePaths::getJavaPath()
 	return AppPath::getSharedDataPath().concatenate(L"data/java/");
 }
 
-FilePath ResourcePaths::getPythonPath()
+FilePath ResourcePaths::getPythonDirectoryPath()
 {
 	return AppPath::getSharedDataPath().concatenate(L"data/python/");
 }
@@ -45,4 +46,13 @@ FilePath ResourcePaths::getPythonPath()
 FilePath ResourcePaths::getCxxCompilerHeaderPath()
 {
 	return AppPath::getSharedDataPath().concatenate(L"data/cxx/include/").getCanonical();
+}
+
+FilePath ResourcePaths::getPythonIndexerFilePath()
+{
+	if (utility::getOsType() == OS_WINDOWS)
+	{
+		return getPythonDirectoryPath().concatenate(L"SourcetrailPythonIndexer.exe");
+	}
+	return getPythonDirectoryPath().concatenate(L"SourcetrailPythonIndexer");
 }

--- a/src/lib/app/paths/ResourcePaths.h
+++ b/src/lib/app/paths/ResourcePaths.h
@@ -15,8 +15,9 @@ public:
 	static FilePath getGuiPath();
 	static FilePath getLicensePath();
 	static FilePath getJavaPath();
-	static FilePath getPythonPath();
+	static FilePath getPythonDirectoryPath();
 	static FilePath getCxxCompilerHeaderPath();
+	static FilePath getPythonIndexerFilePath();
 };
 
 #endif	  // RESOURCE_PATHS_H

--- a/src/lib/data/indexer/IndexerCommandCustom.h
+++ b/src/lib/data/indexer/IndexerCommandCustom.h
@@ -12,7 +12,8 @@ public:
 	static IndexerCommandType getStaticIndexerCommandType();
 
 	IndexerCommandCustom(
-		const std::wstring& customCommand,
+		const std::wstring& command,
+		const std::vector<std::wstring>& arguments,
 		const FilePath& projectFilePath,
 		const FilePath& databaseFilePath,
 		const std::wstring& databaseVersion,
@@ -21,7 +22,8 @@ public:
 
 	IndexerCommandCustom(
 		IndexerCommandType type,
-		const std::wstring& customCommand,
+		const std::wstring& command,
+		const std::vector<std::wstring>& arguments,
 		const FilePath& projectFilePath,
 		const FilePath& databaseFilePath,
 		const std::wstring& databaseVersion,
@@ -34,15 +36,19 @@ public:
 	FilePath getDatabaseFilePath() const;
 	void setDatabaseFilePath(const FilePath& databaseFilePath);
 
-	std::wstring getCustomCommand() const;
+	std::wstring getCommand() const;
+	std::vector<std::wstring> getArguments() const;
 	bool getRunInParallel() const;
 
 protected:
 	QJsonObject doSerialize() const override;
 
 private:
+	std::wstring replaceVariables(std::wstring s) const;
+
 	IndexerCommandType m_type;
-	std::wstring m_customCommand;
+	std::wstring m_command;
+	std::vector<std::wstring> m_arguments;
 	FilePath m_projectFilePath;
 	FilePath m_databaseFilePath;
 	std::wstring m_databaseVersion;

--- a/src/lib/data/indexer/TaskBuildIndex.cpp
+++ b/src/lib/data/indexer/TaskBuildIndex.cpp
@@ -188,22 +188,23 @@ void TaskBuildIndex::runIndexerProcess(int processId, const std::wstring& logFil
 		return;
 	}
 
-	const std::wstring commandPath = L"\"" + indexerProcessPath.wstr() + L"\"";
 	std::vector<std::wstring> commandArguments;
 	commandArguments.push_back(std::to_wstring(processId));
 	commandArguments.push_back(utility::decodeFromUtf8(m_appUUID));
-	commandArguments.push_back(L"\"" + AppPath::getSharedDataPath().getAbsolute().wstr() + L"\"");
-	commandArguments.push_back(L"\"" + UserPaths::getUserDataPath().getAbsolute().wstr() + L"\"");
+	commandArguments.push_back(AppPath::getSharedDataPath().getAbsolute().wstr());
+	commandArguments.push_back(UserPaths::getUserDataPath().getAbsolute().wstr());
 
 	if (!logFilePath.empty())
 	{
-		commandArguments.push_back(L"\"" + logFilePath + L"\"");
+		commandArguments.push_back(logFilePath);
 	}
 
 	int result = 1;
 	while ((!m_indexerCommandQueueStopped || result != 0) && !m_interrupted)
 	{
-		result = utility::executeProcessAndGetExitCode(commandPath, commandArguments, FilePath(), -1);
+		result = utility::executeProcess(
+					 indexerProcessPath.wstr(), commandArguments, FilePath(), false, -1)
+					 .exitCode;
 
 		LOG_INFO_STREAM(<< "Indexer process " << processId << " returned with " + std::to_string(result));
 	}

--- a/src/lib/project/SourceGroupCustomCommand.cpp
+++ b/src/lib/project/SourceGroupCustomCommand.cpp
@@ -42,7 +42,6 @@ std::set<FilePath> SourceGroupCustomCommand::getAllSourceFilePaths() const
 std::vector<std::shared_ptr<IndexerCommand>> SourceGroupCustomCommand::getIndexerCommands(
 	const RefreshInfo& info) const
 {
-	const std::wstring customCommand = m_settings->getCustomCommand();
 	const bool runInParallel = m_settings->getRunInParallel();
 
 	std::vector<std::shared_ptr<IndexerCommand>> indexerCommands;
@@ -51,7 +50,8 @@ std::vector<std::shared_ptr<IndexerCommand>> SourceGroupCustomCommand::getIndexe
 		if (info.filesToIndex.find(sourcePath) != info.filesToIndex.end())
 		{
 			indexerCommands.push_back(std::make_shared<IndexerCommandCustom>(
-				customCommand,
+				m_settings->getCustomCommand(),
+				std::vector<std::wstring> {},
 				m_settings->getProjectSettings()->getProjectFilePath(),
 				m_settings->getProjectSettings()->getTempDBFilePath(),
 				std::to_wstring(SqliteIndexStorage::getStorageVersion()),

--- a/src/lib_gui/qt/project_wizard/content/QtProjectWizardContentSelect.cpp
+++ b/src/lib_gui/qt/project_wizard/content/QtProjectWizardContentSelect.cpp
@@ -24,20 +24,19 @@ void QtProjectWizardContentSelect::populate(QGridLayout* layout, int& row)
 {
 	std::string pythonIndexerVersion = " ";
 	{
-		std::string str =
-			utility::executeProcess(
-				ResourcePaths::getPythonPath().wstr().append(L"SourcetrailPythonIndexer"),
-				std::vector<std::wstring> {L"--version"},
-				FilePath(),
-				5000)
-				.second;
-		std::regex regex(
-			"v\\d*\\.db\\d*\\.p\\d*");	  // "\\d" matches any digit; "\\." matches the "." character
-		std::smatch matches;
-		std::regex_search(str, matches, regex);
-		if (!matches.empty())
+		utility::ProcessOutput output = utility::executeProcess(
+			ResourcePaths::getPythonIndexerFilePath().wstr(), {L"--version"}, FilePath(), false, 5000);
+		if (output.exitCode == 0)
 		{
-			pythonIndexerVersion = matches.str(0) + " ";
+			std::string str = utility::encodeToUtf8(output.output);
+			std::regex regex("v\\d*\\.db\\d*\\.p\\d*");	   // "\\d" matches any digit; "\\." matches
+														   // the "." character
+			std::smatch matches;
+			std::regex_search(str, matches, regex);
+			if (!matches.empty())
+			{
+				pythonIndexerVersion = matches.str(0) + " ";
+			}
 		}
 	}
 

--- a/src/lib_gui/qt/project_wizard/content/path/QtProjectWizardContentPathPythonEnvironment.cpp
+++ b/src/lib_gui/qt/project_wizard/content/path/QtProjectWizardContentPathPythonEnvironment.cpp
@@ -62,20 +62,20 @@ void QtProjectWizardContentPathPythonEnvironment::onTextChanged(const QString& t
 	{
 		m_resultLabel->setText("Checking validity of Python environment...");
 		std::thread([=]() {
-			std::pair<int, std::string> out = utility::executeProcess(
-				ResourcePaths::getPythonPath().wstr().append(L"SourcetrailPythonIndexer"),
-				std::vector<std::wstring>{
-						L"check-environment",
-						L"--environment-path " + utility::getExpandedAndAbsolutePath(
-						FilePath(text.toStdWString()), m_settings->getProjectDirectoryPath())
-						.wstr()
-						},
+			const utility::ProcessOutput out = utility::executeProcess(
+				ResourcePaths::getPythonIndexerFilePath().wstr(),
+				{L"check-environment",
+				 L"--environment-path",
+				 utility::getExpandedAndAbsolutePath(
+					 FilePath(text.toStdWString()), m_settings->getProjectDirectoryPath())
+					 .wstr()},
 				FilePath(),
+				false,
 				5000);
 			m_onQtThread([=]() {
-				if (out.first == 0)
+				if (out.exitCode == 0)
 				{
-					m_resultLabel->setText(QString::fromStdString(out.second));
+					m_resultLabel->setText(QString::fromStdWString(out.output));
 				}
 				else
 				{

--- a/src/lib_gui/utility/path_detector/cxx_header/CxxFrameworkPathDetector.cpp
+++ b/src/lib_gui/utility/path_detector/cxx_header/CxxFrameworkPathDetector.cpp
@@ -11,14 +11,14 @@ CxxFrameworkPathDetector::CxxFrameworkPathDetector(const std::string& compilerNa
 
 std::vector<FilePath> CxxFrameworkPathDetector::doGetPaths() const
 {
-	std::vector<std::string> paths = utility::getCxxHeaderPaths(m_compilerName);
+	std::vector<std::wstring> paths = utility::getCxxHeaderPaths(m_compilerName);
 	std::vector<FilePath> frameworkPaths;
-	for (const std::string& path: paths)
+	for (const std::wstring& path: paths)
 	{
-		if (utility::isPostfix<std::string>(" (framework directory)", path))
+		if (utility::isPostfix<std::wstring>(L" (framework directory)", path))
 		{
 			FilePath p =
-				FilePath(utility::replace(path, " (framework directory)", "")).makeCanonical();
+				FilePath(utility::replace(path, L" (framework directory)", L"")).makeCanonical();
 			if (p.exists())
 			{
 				frameworkPaths.push_back(p);

--- a/src/lib_gui/utility/path_detector/cxx_header/CxxHeaderPathDetector.cpp
+++ b/src/lib_gui/utility/path_detector/cxx_header/CxxHeaderPathDetector.cpp
@@ -11,12 +11,12 @@ CxxHeaderPathDetector::CxxHeaderPathDetector(const std::string& compilerName)
 
 std::vector<FilePath> CxxHeaderPathDetector::doGetPaths() const
 {
-	std::vector<std::string> paths = utility::getCxxHeaderPaths(m_compilerName);
+	std::vector<std::wstring> paths = utility::getCxxHeaderPaths(m_compilerName);
 	std::vector<FilePath> headerSearchPaths;
 
-	for (const std::string& path: paths)
+	for (const std::wstring& path: paths)
 	{
-		if (!utility::isPostfix<std::string>(" (framework directory)", path) &&
+		if (!utility::isPostfix<std::wstring>(L" (framework directory)", path) &&
 			FilePath(path).getCanonical().exists() &&
 			!FilePath(path).getCanonical().getConcatenated(L"/stdarg.h").exists())
 		{

--- a/src/lib_gui/utility/path_detector/cxx_header/CxxVs15HeaderPathDetector.cpp
+++ b/src/lib_gui/utility/path_detector/cxx_header/CxxVs15HeaderPathDetector.cpp
@@ -20,27 +20,32 @@ std::vector<FilePath> CxxVs15HeaderPathDetector::doGetPaths() const
 				.expandEnvironmentVariables();
 		if (!expandedPaths.empty())
 		{
-			const std::string output =
-				utility::executeProcess(
-					expandedPaths[0].wstr(), std::vector<std::wstring> {L"-latest", L"-property installationPath"}, FilePath(), 10000)
-					.second;
-
-			const FilePath vsInstallPath(output);
-			if (vsInstallPath.exists())
+			const utility::ProcessOutput out = utility::executeProcess(
+				expandedPaths.front().wstr(),
+				{L"-latest", L"-property", L"installationPath"},
+				FilePath(),
+				false,
+				10000);
+			if (out.exitCode == 0)
 			{
-				for (const FilePath& versionPath: FileSystem::getDirectSubDirectories(
-						 vsInstallPath.getConcatenated(L"VC/Tools/MSVC")))
+				const FilePath vsInstallPath(out.output);
+				if (vsInstallPath.exists())
 				{
-					if (versionPath.exists())
+					for (const FilePath& versionPath: FileSystem::getDirectSubDirectories(
+							 vsInstallPath.getConcatenated(L"VC/Tools/MSVC")))
 					{
-						headerSearchPaths.push_back(versionPath.getConcatenated(L"include"));
-						headerSearchPaths.push_back(versionPath.getConcatenated(L"atlmfc/include"));
+						if (versionPath.exists())
+						{
+							headerSearchPaths.push_back(versionPath.getConcatenated(L"include"));
+							headerSearchPaths.push_back(
+								versionPath.getConcatenated(L"atlmfc/include"));
+						}
 					}
+					headerSearchPaths.push_back(
+						vsInstallPath.getConcatenated(L"VC/Auxiliary/VS/include"));
+					headerSearchPaths.push_back(
+						vsInstallPath.getConcatenated(L"VC/Auxiliary/VS/UnitTest/include"));
 				}
-				headerSearchPaths.push_back(
-					vsInstallPath.getConcatenated(L"VC/Auxiliary/VS/include"));
-				headerSearchPaths.push_back(
-					vsInstallPath.getConcatenated(L"VC/Auxiliary/VS/UnitTest/include"));
 			}
 		}
 	}

--- a/src/lib_gui/utility/path_detector/cxx_header/utilityCxxHeaderDetection.cpp
+++ b/src/lib_gui/utility/path_detector/cxx_header/utilityCxxHeaderDetection.cpp
@@ -9,22 +9,23 @@
 
 namespace utility
 {
-std::vector<std::string> getCxxHeaderPaths(const std::string& compilerName)
+std::vector<std::wstring> getCxxHeaderPaths(const std::string& compilerName)
 {
-	std::string command = compilerName + " -x c++ -v -E /dev/null";
-	std::string clangOutput = utility::executeProcess(
-								  utility::decodeFromUtf8(compilerName),
-								  std::vector<std::wstring> {L"-x c++", L"-v", L"-E /dev/null"})
-								  .second;
-	std::string standardHeaders = utility::substrBetween<std::string>(
-		clangOutput, "#include <...> search starts here:\n", "\nEnd of search list");
-	std::vector<std::string> paths;
+	std::vector<std::wstring> paths;
 
-	if (!standardHeaders.empty())
+	const utility::ProcessOutput out = utility::executeProcess(
+		utility::decodeFromUtf8(compilerName), {L"-x", L"c++", L"-v", L"-E", L"/dev/null"});
+	if (out.exitCode == 0)
 	{
-		for (const std::string& s: utility::splitToVector(standardHeaders, '\n'))
+		std::wstring standardHeaders = utility::substrBetween<std::wstring>(
+			out.output, L"#include <...> search starts here:\n", L"\nEnd of search list");
+
+		if (!standardHeaders.empty())
 		{
-			paths.push_back(utility::trim(s));
+			for (const std::wstring& s: utility::splitToVector(standardHeaders, L'\n'))
+			{
+				paths.push_back(utility::trim(s));
+			}
 		}
 	}
 

--- a/src/lib_gui/utility/path_detector/cxx_header/utilityCxxHeaderDetection.h
+++ b/src/lib_gui/utility/path_detector/cxx_header/utilityCxxHeaderDetection.h
@@ -9,7 +9,7 @@
 
 namespace utility
 {
-std::vector<std::string> getCxxHeaderPaths(const std::string& compilerName);
+std::vector<std::wstring> getCxxHeaderPaths(const std::string& compilerName);
 
 std::vector<FilePath> getWindowsSdkHeaderSearchPaths(ApplicationArchitectureType architectureType);
 FilePath getWindowsSdkRootPathUsingRegistry(

--- a/src/lib_gui/utility/path_detector/java_runtime/JavaPathDetectorLinux.cpp
+++ b/src/lib_gui/utility/path_detector/java_runtime/JavaPathDetectorLinux.cpp
@@ -54,28 +54,28 @@ std::vector<FilePath> JavaPathDetectorLinux::doGetPaths() const
 
 FilePath JavaPathDetectorLinux::getJavaInPath() const
 {
-	std::string output = utility::executeProcess(L"which", std::vector<std::wstring>{L"java"}).second;
-
-	if (!output.empty())
+	bool ok;
+	FilePath javaPath(utility::searchPath(L"java", ok));
+	if (ok && !javaPath.empty() && javaPath.exists())
 	{
-		output = utility::trim(output);
-
-		FilePath javaPath(output);
-		if (!javaPath.empty() && javaPath.exists())
-		{
-			return javaPath;
-		}
+		return javaPath;
 	}
-
 	return FilePath();
 }
 
 FilePath JavaPathDetectorLinux::readLink(const FilePath& path) const
 {
-	FilePath javaPath(utility::executeProcess(L"readlink", std::vector<std::wstring>{L"-f", path.wstr()}).second);
-	if (!javaPath.empty())
+	const utility::ProcessOutput out = utility::executeProcess(
+		L"readlink", std::vector<std::wstring> {L"-f", path.wstr()});
+
+	if (out.exitCode == 0 && !out.output.empty())
 	{
-		return javaPath;
+		FilePath javaPath(utility::trim(out.output));
+
+		if (!javaPath.empty())
+		{
+			return javaPath;
+		}
 	}
 	return FilePath();
 }
@@ -113,7 +113,9 @@ FilePath JavaPathDetectorLinux::getJavaInJavaHome() const
 
 bool JavaPathDetectorLinux::checkVersion(const FilePath& path) const
 {
-	std::string output = utility::executeProcess(path.wstr(), std::vector<std::wstring>{L"-version"}).second;
+	const utility::ProcessOutput out = utility::executeProcess(path.wstr(), {L"-version"});
 
-	return output.find(m_javaVersion) != std::string::npos;
+	return (
+		(out.exitCode == 0) &&
+		(out.output.find(utility::decodeFromUtf8(m_javaVersion)) != std::string::npos));
 }

--- a/src/lib_gui/utility/path_detector/java_runtime/JavaPathDetectorMac.cpp
+++ b/src/lib_gui/utility/path_detector/java_runtime/JavaPathDetectorMac.cpp
@@ -14,21 +14,22 @@ std::vector<FilePath> JavaPathDetectorMac::doGetPaths() const
 	std::vector<FilePath> paths;
 	FilePath javaPath;
 
-	std::string output = utility::executeProcess(L"/usr/libexec/java_home", std::vector<std::wstring>{}).second;
+	const utility::ProcessOutput out = utility::executeProcess(L"/usr/libexec/java_home", {});
 
+	const std::wstring output = out.exitCode == 0 ? utility::trim(out.output) : L"";
 	if (!output.empty())
 	{
-		javaPath = FilePath(utility::trim(output) + "/../MacOS/libjli.dylib").makeCanonical();
+		javaPath = FilePath(output + L"/../MacOS/libjli.dylib").makeCanonical();
 	}
 
-	if (!javaPath.exists() && output.size())
+	if (!javaPath.exists() && !output.empty())
 	{
-		javaPath = FilePath(utility::trim(output) + "/lib/libjli.dylib");
+		javaPath = FilePath(output + L"/lib/libjli.dylib");
 	}
 
-	if (!javaPath.exists() && output.size())
+	if (!javaPath.exists() && !output.empty())
 	{
-		javaPath = FilePath(utility::trim(output) + "/jre/lib/jli/libjli.dylib");
+		javaPath = FilePath(output + L"/jre/lib/jli/libjli.dylib");
 	}
 
 	if (!javaPath.exists())
@@ -36,9 +37,9 @@ std::vector<FilePath> JavaPathDetectorMac::doGetPaths() const
 		javaPath = FilePath(L"/usr/lib/libjli.dylib");
 	}
 
-	if (!javaPath.exists() && output.size())
+	if (!javaPath.exists() && !output.empty())
 	{
-		javaPath = FilePath(utility::trim(output) + "/jre/lib/server/libjvm.dylib");
+		javaPath = FilePath(output + L"/jre/lib/server/libjvm.dylib");
 	}
 
 	if (!javaPath.exists())

--- a/src/lib_gui/utility/path_detector/maven_executable/MavenPathDetectorUnix.cpp
+++ b/src/lib_gui/utility/path_detector/maven_executable/MavenPathDetectorUnix.cpp
@@ -7,12 +7,17 @@ MavenPathDetectorUnix::MavenPathDetectorUnix(): PathDetector("Maven for Unix") {
 
 std::vector<FilePath> MavenPathDetectorUnix::doGetPaths() const
 {
-	FilePath mavenPath(utility::executeProcess(L"which", std::vector<std::wstring>{L"mvn"}).second);
-
 	std::vector<FilePath> paths;
-	if (mavenPath.exists())
+
+	const utility::ProcessOutput out = utility::executeProcess(L"which", {L"mvn"});
+
+	if (out.exitCode == 0)
 	{
-		paths.push_back(mavenPath);
+		FilePath mavenPath(out.output);
+		if (mavenPath.exists())
+		{
+			paths.push_back(mavenPath);
+		}
 	}
 	return paths;
 }

--- a/src/lib_gui/utility/path_detector/maven_executable/MavenPathDetectorWindows.cpp
+++ b/src/lib_gui/utility/path_detector/maven_executable/MavenPathDetectorWindows.cpp
@@ -7,10 +7,11 @@ MavenPathDetectorWindows::MavenPathDetectorWindows(): PathDetector("Maven for Wi
 
 std::vector<FilePath> MavenPathDetectorWindows::doGetPaths() const
 {
-	FilePath mavenPath(utility::executeProcess(L"cmd", std::vector<std::wstring>{L"/c where mvn.cmd && exit"}).second);
-
 	std::vector<FilePath> paths;
-	if (mavenPath.exists())
+
+	bool ok;
+	FilePath mavenPath(utility::searchPath(L"mvn.cmd", ok));
+	if (ok && !mavenPath.empty() && mavenPath.exists())
 	{
 		paths.push_back(mavenPath);
 	}

--- a/src/lib_gui/utility/utilityApp.h
+++ b/src/lib_gui/utility/utilityApp.h
@@ -9,25 +9,27 @@
 
 namespace utility
 {
-std::pair<int, std::string> executeProcess(
-	const std::wstring& commandPath,
-	const std::vector<std::wstring>& commandArguments,
+struct ProcessOutput
+{
+	std::wstring output;
+	std::wstring error;
+	int exitCode;
+};
+
+std::wstring searchPath(const std::wstring& bin, bool& ok);
+
+std::wstring searchPath(const std::wstring& bin);
+
+ProcessOutput executeProcess(
+	const std::wstring& command,
+	const std::vector<std::wstring>& arguments,
 	const FilePath& workingDirectory = FilePath(),
-	const int timeout = 30000);
-std::string executeProcessUntilNoOutput(
-	const std::wstring& commandPath,
-	const std::vector<std::wstring>& commandArguments,
-	const FilePath& workingDirectory,
-	int waitTime = 10000);
-int executeProcessAndGetExitCode(
-	const std::wstring& commandPath,
-	const std::vector<std::wstring>& commandArguments,
-	const FilePath& workingDirectory = FilePath(),
+	const bool waitUntilNoOutput = false,
 	const int timeout = 30000,
-	bool logProcessOutput = false,
-	std::wstring* errorMessage = nullptr);
+	bool logProcessOutput = false);
 
 void killRunningProcesses();
+
 int getIdealThreadCount();
 
 constexpr OsType getOsType()

--- a/src/lib_java/utility/utilityMaven.cpp
+++ b/src/lib_java/utility/utilityMaven.cpp
@@ -104,12 +104,8 @@ std::wstring mavenGenerateSources(
 	auto args = getMavenArgs(settingsFilePath);
 	args.push_back(L"generate-sources");
 
-	std::shared_ptr<TextAccess> outputAccess = TextAccess::createFromString(
-		utility::executeProcessUntilNoOutput(
-			mavenPath.wstr(),
-			args,
-			projectDirectoryPath,
-			60000));
+	std::shared_ptr<TextAccess> outputAccess = TextAccess::createFromString(utility::encodeToUtf8(
+		utility::executeProcess(mavenPath.wstr(), args, projectDirectoryPath, true, 60000).output));
 
 	if (outputAccess->isEmpty())
 	{
@@ -132,12 +128,8 @@ bool mavenCopyDependencies(
 	args.push_back(L"dependency:copy-dependencies");
 	args.push_back(L"-DoutputDirectory=" + outputDirectoryPath.wstr());
 
-	std::shared_ptr<TextAccess> outputAccess = TextAccess::createFromString(
-			utility::executeProcessUntilNoOutput(
-					mavenPath.wstr(),
-					args,
-					projectDirectoryPath,
-			60000));
+	std::shared_ptr<TextAccess> outputAccess = TextAccess::createFromString(utility::encodeToUtf8(
+		utility::executeProcess(mavenPath.wstr(), args, projectDirectoryPath, true, 60000).output));
 
 	const std::wstring errorMessage = getErrorMessageFromMavenOutput(outputAccess);
 	if (!errorMessage.empty())
@@ -165,12 +157,8 @@ std::vector<FilePath> mavenGetAllDirectoriesFromEffectivePom(
 	args.push_back(L"help:effective-pom");
 	args.push_back(L"-Doutput=" + outputPath.wstr());
 
-	std::shared_ptr<TextAccess> outputAccess = TextAccess::createFromString(
-			utility::executeProcessUntilNoOutput(
-					mavenPath.wstr(),
-					args,
-					projectDirectoryPath,
-			60000));
+	std::shared_ptr<TextAccess> outputAccess = TextAccess::createFromString(utility::encodeToUtf8(
+		utility::executeProcess(mavenPath.wstr(), args, projectDirectoryPath, true, 60000).output));
 
 	const std::wstring errorMessage = getErrorMessageFromMavenOutput(outputAccess);
 	if (!errorMessage.empty())

--- a/src/lib_python/project/SourceGroupPythonEmpty.cpp
+++ b/src/lib_python/project/SourceGroupPythonEmpty.cpp
@@ -49,25 +49,28 @@ std::set<FilePath> SourceGroupPythonEmpty::getAllSourceFilePaths() const
 std::vector<std::shared_ptr<IndexerCommand>> SourceGroupPythonEmpty::getIndexerCommands(
 	const RefreshInfo& info) const
 {
-	std::wstring args = L"";
+	std::vector<std::wstring> args;
+	args.push_back(L"index");
 
-	args += L" --source-file-path=%{SOURCE_FILE_PATH}";
-	args += L" --database-file-path=%{DATABASE_FILE_PATH}";
+	args.push_back(L"--source-file-path");
+	args.push_back(L"%{SOURCE_FILE_PATH}");
+	args.push_back(L"--database-file-path");
+	args.push_back(L"%{DATABASE_FILE_PATH}");
 
 	if (!m_settings->getEnvironmentPath().empty())
 	{
-		args += L" --environment-path=\"" +
-			m_settings->getEnvironmentPathExpandedAndAbsolute().wstr() + L"\"";
+		args.push_back(L"--environment-path");
+		args.push_back(m_settings->getEnvironmentPathExpandedAndAbsolute().wstr());
 	}
 
 	if (ApplicationSettings::getInstance()->getVerboseIndexerLoggingEnabled())
 	{
-		args += L" --verbose";
+		args.push_back(L"--verbose");
 	}
 
 	if (info.shallow)
 	{
-		args += L" --shallow";
+		args.push_back(L"--shallow");
 	}
 
 	std::vector<std::shared_ptr<IndexerCommand>> indexerCommands;
@@ -77,8 +80,8 @@ std::vector<std::shared_ptr<IndexerCommand>> SourceGroupPythonEmpty::getIndexerC
 		{
 			indexerCommands.push_back(std::make_shared<IndexerCommandCustom>(
 				INDEXER_COMMAND_PYTHON,
-				L"\"" + ResourcePaths::getPythonPath().wstr() +
-					L"SourcetrailPythonIndexer\" index" + args,
+				ResourcePaths::getPythonIndexerFilePath().wstr(),
+				args,
 				m_settings->getProjectSettings()->getProjectFilePath(),
 				m_settings->getProjectSettings()->getTempDBFilePath(),
 				std::to_wstring(SqliteIndexStorage::getStorageVersion()),

--- a/src/test/SourceGroupTestSuite.cpp
+++ b/src/test/SourceGroupTestSuite.cpp
@@ -148,9 +148,15 @@ std::wstring indexerCommandCustomToString(
 	std::shared_ptr<const IndexerCommandCustom> indexerCommand, const FilePath& baseDirectory)
 {
 	std::wstring result;
-	result += L"SourceFilePath: \"" +
+	result += L"IndexerCommandCustom\n";
+	result += L"\tSourceFilePath: \"" +
 		indexerCommand->getSourceFilePath().getRelativeTo(baseDirectory).wstr() + L"\"\n";
-	result += L"\tCustom Command: \"" + indexerCommand->getCustomCommand() + L"\"\n";
+	result += L"\tCustom Command: \"" + indexerCommand->getCommand() + L"\"\n";
+	result += L"\tArguments:\n";
+	for (const std::wstring& argument: indexerCommand->getArguments())
+	{
+		result += L"\t\t\"" + argument + L"\"\n";
+	}
 	return result;
 }
 


### PR DESCRIPTION
* changed implementation of executeProcess
* unified all different implementations of executeProcess
* separated arg list from command for all calls of executeProcess (this also required to remove quotes that were added to path args because otherwise the Python indexer would mistake absolute paths for relative paths.)
* update expected output for custom command tests