### PR TITLE
remove call to boost::filesystem::canonical when preparing indexer (issue #1149)

### DIFF
--- a/src/lib/utility/file/FileSystem.cpp
+++ b/src/lib/utility/file/FileSystem.cpp
@@ -63,7 +63,7 @@ std::vector<FileInfo> FileSystem::getFileInfosFromPaths(
 	}
 
 	std::set<boost::filesystem::path> symlinkDirs;
-	std::set<boost::filesystem::path> filePaths;
+	std::set<FilePath> filePaths;
 
 	std::vector<FileInfo> files;
 
@@ -112,25 +112,24 @@ std::vector<FileInfo> FileSystem::getFileInfosFromPaths(
 					(ext.empty() ||
 					 ext.find(utility::toLowerCase(it->path().extension().wstring())) != ext.end()))
 				{
-					boost::filesystem::path p = boost::filesystem::canonical(it->path());
-					if (filePaths.find(p) != filePaths.end())
+					const FilePath canonicalPath = FilePath(it->path().wstring()).getCanonical();
+					if (filePaths.find(canonicalPath) != filePaths.end())
 					{
 						continue;
 					}
-					filePaths.insert(p);
-					files.push_back(getFileInfoForPath(FilePath(it->path().wstring())));
+					filePaths.insert(canonicalPath);
+					files.push_back(getFileInfoForPath(canonicalPath));
 				}
 			}
 		}
 		else if (path.exists() && (ext.empty() || ext.find(utility::toLowerCase(path.extension())) != ext.end()))
 		{
 			const FilePath canonicalPath = path.getCanonical();
-			boost::filesystem::path p = canonicalPath.getPath();
-			if (filePaths.find(p) != filePaths.end())
+			if (filePaths.find(canonicalPath) != filePaths.end())
 			{
 				continue;
 			}
-			filePaths.insert(p);
+			filePaths.insert(canonicalPath);
 			files.push_back(getFileInfoForPath(canonicalPath));
 		}
 	}

--- a/src/test/FileSystemTestSuite.cpp
+++ b/src/test/FileSystemTestSuite.cpp
@@ -19,7 +19,7 @@ bool isInFileInfos(const std::vector<FileInfo>& infos, const std::wstring& filen
 {
 	for (const FileInfo& info: infos)
 	{
-		if (info.path.wstr() == filename)
+		if (info.path.getAbsolute().wstr() == FilePath(filename).getCanonical().wstr())
 		{
 			return true;
 		}
@@ -33,7 +33,8 @@ bool isInFileInfos(
 {
 	for (const FileInfo& info: infos)
 	{
-		if (info.path.wstr() == filename || info.path.wstr() == filename2)
+		if (info.path.wstr() == FilePath(filename).getCanonical().wstr() ||
+			info.path.wstr() == FilePath(filename2).getCanonical().wstr())
 		{
 			return true;
 		}


### PR DESCRIPTION
boost::filesystem::canonical causes issues on Windows and will throw an exception if path is too long.