### PR TITLE
Adapt cmake -DBOOST_ROOT path in README to reflect downgrade of boost

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Building Sourcetrail requires several dependencies to be in place on your machin
     $ cd Sourcetrail
     $ mkdir -p build/win64
     $ cd build/win64
-    $ cmake -G "Visual Studio 15 2017 Win64" -DBOOST_ROOT=<path/to/boost_1_68_0> -DQt5_DIR=<path/to/Qt/version/platform/compiler/lib/cmake/Qt5> ../..
+    $ cmake -G "Visual Studio 15 2017 Win64" -DBOOST_ROOT=<path/to/boost_1_67_0> -DQt5_DIR=<path/to/Qt/version/platform/compiler/lib/cmake/Qt5> ../..
     ```
     _Hint: If you are using the CMake GUI, we recommend that you activate advanced mode. Also you may be required to add some of the defines via the "Add Entry" button._
 
@@ -126,7 +126,7 @@ Building Sourcetrail requires several dependencies to be in place on your machin
     $ cd Sourcetrail
     $ mkdir -p build/Release
     $ cd build/Release
-    $ cmake -DCMAKE_BUILD_TYPE="Release" -DBOOST_ROOT=<path/to/boost_1_68_0> -DQt5_DIR=<path/to/Qt/version/platform/compiler/lib/cmake/Qt5> ../..
+    $ cmake -DCMAKE_BUILD_TYPE="Release" -DBOOST_ROOT=<path/to/boost_1_67_0> -DQt5_DIR=<path/to/Qt/version/platform/compiler/lib/cmake/Qt5> ../..
     ```
 * Now start the build with:
     ```


### PR DESCRIPTION
With #775 Boost was downgraded to 1.67 (from 1.68).
With pull request #807 the readme file was corrected. But this correction was not complete. The example path for the -DBOOST_ROOT parameter of cmake was left unchanged.
This inconsistency took me some time to understand. So I propose to adapt the path also.