### PR TITLE
logic: update SourcetrailPythonIndexer to version 1.25.6 to fix TextAccess issue

### DIFF
--- a/script/download_python_indexer.sh
+++ b/script/download_python_indexer.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SOURCETRAIL_PYTHON_INDEXER_VERSION="v1_db25_p5"
+SOURCETRAIL_PYTHON_INDEXER_VERSION="v1_db25_p6"
 
 # Determine current platform
 PLATFORM='unknown'

--- a/src/lib/data/indexer/TaskExecuteCustomCommands.cpp
+++ b/src/lib/data/indexer/TaskExecuteCustomCommands.cpp
@@ -73,7 +73,7 @@ void TaskExecuteCustomCommands::runPythonPostProcessing(PersistentStorage& stora
 			return;
 		}
 
-		std::shared_ptr<TextAccess> textAccess = TextAccess::createFromFile(filePath);
+		std::shared_ptr<TextAccess> textAccess = storage.getFileContent(filePath, false);
 		if (textAccess)
 		{
 			std::map<std::wstring, std::vector<std::wstring>> childToParentNodesMap;

--- a/src/lib/utility/text/TextAccess.cpp
+++ b/src/lib/utility/text/TextAccess.cpp
@@ -21,7 +21,7 @@ std::istream& safeGetline(std::istream& is, std::string& t)
 
 	while (true)
 	{
-		int c = sb->sbumpc();
+		const int c = sb->sbumpc();
 		switch (c)
 		{
 		case '\n':
@@ -76,8 +76,6 @@ std::shared_ptr<TextAccess> TextAccess::createFromLines(
 
 	return result;
 }
-
-TextAccess::~TextAccess() {}
 
 unsigned int TextAccess::getLineCount() const
 {
@@ -142,7 +140,7 @@ std::vector<std::string> TextAccess::readFile(const FilePath& filePath)
 	try
 	{
 		std::ifstream srcFile;
-		srcFile.open(filePath.str());
+		srcFile.open(filePath.str(), std::ios::binary | std::ios::in);
 
 		if (srcFile.fail())
 		{

--- a/src/lib/utility/text/TextAccess.h
+++ b/src/lib/utility/text/TextAccess.h
@@ -16,7 +16,7 @@ public:
 	static std::shared_ptr<TextAccess> createFromLines(
 		const std::vector<std::string>& lines, const FilePath& filePath = FilePath());
 
-	virtual ~TextAccess();
+	virtual ~TextAccess() = default;
 
 	unsigned int getLineCount() const;
 	bool isEmpty() const;


### PR DESCRIPTION
* before this update the SourcetrailPythonIndexer was saving indexed code to the database different than Sourcetrail, which could result in crashes