### PR TITLE
Replace timestamp endpoint

### DIFF
--- a/script/deploy_windows.sh
+++ b/script/deploy_windows.sh
@@ -89,13 +89,13 @@ echo -e "$INFO Building the project"
 
 if [ $RUN_CODE_SIGNING = true ]; then
 	echo -e "$INFO Signing the app"
-	signtool.exe sign //sha1 $CODE_SIGNING_THUMBPRINT //fd sha256 //t "http://timestamp.verisign.com/scripts/timstamp.dll" //d "Sourcetrail ${DOTTED_VERSION_STRING}" //du "https://www.sourcetrail.com/" //v build/Release/app/Sourcetrail.exe
+	signtool.exe sign //sha1 $CODE_SIGNING_THUMBPRINT //fd sha256 //t "http://sha256timestamp.ws.symantec.com/sha256/timestamp" //d "Sourcetrail ${DOTTED_VERSION_STRING}" //du "https://www.sourcetrail.com/" //v build/Release/app/Sourcetrail.exe
 	
 	echo -e "$INFO Signing the indexer"
-	signtool.exe sign //sha1 $CODE_SIGNING_THUMBPRINT //fd sha256 //t "http://timestamp.verisign.com/scripts/timstamp.dll" //d "Sourcetrail Indexer ${DOTTED_VERSION_STRING}" //du "https://www.sourcetrail.com/" //v build/Release/app/sourcetrail_indexer.exe
+	signtool.exe sign //sha1 $CODE_SIGNING_THUMBPRINT //fd sha256 //t "http://sha256timestamp.ws.symantec.com/sha256/timestamp" //d "Sourcetrail Indexer ${DOTTED_VERSION_STRING}" //du "https://www.sourcetrail.com/" //v build/Release/app/sourcetrail_indexer.exe
 	
 	echo -e "$INFO Signing the Python indexer"
-	signtool.exe sign //sha1 $CODE_SIGNING_THUMBPRINT //fd sha256 //t "http://timestamp.verisign.com/scripts/timstamp.dll" //d "Sourcetrail Python Indexer" //du "https://github.com/CoatiSoftware/SourcetrailPythonIndexer" //v bin/app/data/python/SourcetrailPythonIndexer.exe
+	signtool.exe sign //sha1 $CODE_SIGNING_THUMBPRINT //fd sha256 //t "http://sha256timestamp.ws.symantec.com/sha256/timestamp" //d "Sourcetrail Python Indexer" //du "https://github.com/CoatiSoftware/SourcetrailPythonIndexer" //v bin/app/data/python/SourcetrailPythonIndexer.exe
 fi
 
 
@@ -151,7 +151,7 @@ cd ../../..
 
 if [ $RUN_CODE_SIGNING = true ]; then
 	echo -e "$INFO Signing the 64 bit windows installer"
-	signtool.exe sign //sha1 $CODE_SIGNING_THUMBPRINT //fd sha256 //t "http://timestamp.verisign.com/scripts/timstamp.dll" //d "Sourcetrail ${DOTTED_VERSION_STRING} Installer" //du "https://www.sourcetrail.com/" //v deployment/windows/wixSetup/bin/sourcetrail.msi
+	signtool.exe sign //sha1 $CODE_SIGNING_THUMBPRINT //fd sha256 //t "http://sha256timestamp.ws.symantec.com/sha256/timestamp" //d "Sourcetrail ${DOTTED_VERSION_STRING} Installer" //du "https://www.sourcetrail.com/" //v deployment/windows/wixSetup/bin/sourcetrail.msi
 fi
 
 


### PR DESCRIPTION
https://github.com/CoatiSoftware/Sourcetrail/pull/1162#discussion_r593389410

`timstamp` is an 8.3 thing, but Verisign's `timstamp` endpoint died ages ago. You can pick any replacement you like. Symantec is roughly of similar caliber to Verisign, hence the choice. But it doesn't really matter to me.

It's also fine to split this out, as it's a behavior change -- albeit from "using a service that doesn't exist at all":
```
curl -vvv http://timestamp.verisign.com/scripts/timstamp.dll
*   Trying 216.168.248.38...
* TCP_NODELAY set
* Connection failed
* connect to 216.168.248.38 port 80 failed: Network is unreachable
* Failed to connect to timestamp.verisign.com port 80: Network is unreachable
* Closing connection 0
curl: (7) Failed to connect to timestamp.verisign.com port 80: Network is unreachable
```
to one that could actually work...