### PR TITLE
Add support for LLVM 12

### DIFF
--- a/src/lib_cxx/data/parser/cxx/ClangInvocationInfo.cpp
+++ b/src/lib_cxx/data/parser/cxx/ClangInvocationInfo.cpp
@@ -5,6 +5,7 @@
 #include <clang/Driver/Options.h>
 #include <clang/Frontend/CompilerInvocation.h>
 #include <clang/Tooling/Tooling.h>
+#include <clang/Basic/Version.h>
 #include <llvm/Option/ArgList.h>
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Support/Host.h>
@@ -21,9 +22,16 @@ clang::driver::Driver* newDriver(
 	const char* BinaryName,
 	clang::IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS)
 {
+	#if CLANG_VERSION_MAJOR > 11
 	clang::driver::Driver* CompilerDriver = new clang::driver::Driver(
-		BinaryName, llvm::sys::getDefaultTargetTriple(), *Diagnostics, std::move(VFS));
+		BinaryName, llvm::sys::getDefaultTargetTriple(), *Diagnostics,
+		"clang_based_tool", std::move(VFS));
+	#else
+	clang::driver::Driver* CompilerDriver = new clang::driver::Driver(
+		BinaryName, llvm::sys::getDefaultTargetTriple(), *Diagnostics,
+		std::move(VFS));
 	CompilerDriver->setTitle("clang_based_tool");
+	#endif
 	return CompilerDriver;
 }
 }	 // namespace


### PR DESCRIPTION
This PR adds support for LLVM 12.

The title of the driver was integrated into the constructor: https://github.com/llvm/llvm-project/commit/257b29715bb27b7d9f6c3c40c481b6a4af0b37e5