### PR TITLE
fixed #1197 FUNCTION syntax highlighting overwrittes KEYWORD When no …

### DIFF
--- a/bin/app/data/syntax_highlighting_rules/cpp.rules
+++ b/bin/app/data/syntax_highlighting_rules/cpp.rules
@@ -18,6 +18,10 @@
 		"priority" : true
 	},
 	{
+		"type" : "function",
+		"patterns" : [ "\\b[A-Za-z0-9_]+(?=\\()" ]
+	},
+	{
 		"type" : "keyword",
 		"patterns" : [
 			"\\balignas\\b",
@@ -158,10 +162,6 @@
 	{
 		"type" : "number",
 		"patterns" : [ "\\b[0-9]+\\b" ]
-	},
-	{
-		"type" : "function",
-		"patterns" : [ "\\b[A-Za-z0-9_]+(?=\\()" ]
 	},
 	{
 		"type" : "quotation",


### PR DESCRIPTION
…space between KEYWORD and "("

by moving FUNCTION rule in cpp.rules above KEYWORD rules