### PR TITLE
fix #1201 - color_scheme <line_number><background> ignored

### DIFF
--- a/src/lib_gui/qt/element/code/QtCodeArea.cpp
+++ b/src/lib_gui/qt/element/code/QtCodeArea.cpp
@@ -32,7 +32,7 @@
 #include "utility.h"
 #include "utilityApp.h"
 #include "utilityString.h"
-#include "utilityQt.cpp"
+#include "utilityQt.h"
 
 MouseWheelOverScrollbarFilter::MouseWheelOverScrollbarFilter() {}
 

--- a/src/lib_gui/qt/element/code/QtCodeArea.cpp
+++ b/src/lib_gui/qt/element/code/QtCodeArea.cpp
@@ -32,6 +32,7 @@
 #include "utility.h"
 #include "utilityApp.h"
 #include "utilityString.h"
+#include "utilityQt.cpp"
 
 MouseWheelOverScrollbarFilter::MouseWheelOverScrollbarFilter() {}
 
@@ -143,6 +144,9 @@ QSize QtCodeArea::sizeHint() const
 void QtCodeArea::lineNumberAreaPaintEvent(QPaintEvent* event)
 {
 	QPainter painter(m_lineNumberArea);
+
+	utility::setWidgetBackgroundColor(
+		m_lineNumberArea, ColorScheme::getInstance()->getColor("code/snippet/line_number/background"));
 
 	QTextBlock block = firstVisibleBlock();
 	int blockNumber = block.blockNumber();


### PR DESCRIPTION
fix #1201 where setting the background color for line numbers in color_scheme is ignored.