### PR TITLE
docs: missing close list tag added

### DIFF
--- a/docs/documentation/index.html
+++ b/docs/documentation/index.html
@@ -2697,6 +2697,7 @@
 						<li>Click Marketplace tab</li>
 						<li>Search for idea-sourcetrail</li>
 						<li>Click Install for idea-sourcetrail plugin</li>
+					</ol>
 					</p>
 					<strong>Use</strong>
 					<p>If you want IntelliJ IDEA/CLion to activate a certain element in Sourcetrail, right-click that element to


### PR DESCRIPTION
The `Use` section was misaligned due to unclosed html tag in the list.
![image](https://user-images.githubusercontent.com/9664767/133207961-e007cdff-d570-49df-bfa2-4073c0da0d3e.png)
